### PR TITLE
add another parse test with a different TOML layout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ mod test {
         let test_files = vec![
             "test/data/simple-invoice.toml",
             "test/data/full-invoice.toml",
+            "test/data/alt-format-invoice.toml",
         ];
         test_files.iter().for_each(|file| test_parsing_a_file(file));
     }

--- a/test/data/alt-format-invoice.toml
+++ b/test/data/alt-format-invoice.toml
@@ -1,0 +1,32 @@
+bindleVersion = "1.0.0"
+
+[bindle]
+name = "mybindle"
+version = "0.1.0"
+authors = ["Matt Butcher <matt.butcher@microsoft.com>"]
+description = "My first bindle"
+
+[annotations]
+myname = "myvalue"
+
+[[parcel]]
+
+[parcel.label]
+sha256 = "e1706ab0a39ac88094b6d54a3f5cdba41fe5a901"
+mediaType = "text/html"
+name = "myparcel.html"
+
+# Experimental support for conditional inclusions
+[parcel.conditions]
+memberOf = ["server"]
+
+[[parcel]]
+label.sha256 = "098fa798779ac88094b6d54a3f5cdba41fe5a901"
+label.name = "style.css"
+label.mediaType = "text/css"
+
+[[parcel]]
+label.sha256 = "5b992e90b71d5fadab3cd3777230ef370df75f5b"
+label.mediaType = "application/x-javascript"
+label.name = "foo.js"
+label.size = 248098


### PR DESCRIPTION
This test just makes sure that a second variant of the TOML format is parsing correctly.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>