### PR TITLE
warm the search index on startup

### DIFF
--- a/bin/server.rs
+++ b/bin/server.rs
@@ -42,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
     let dir = app.value_of("dir").unwrap_or("/tmp");
     let addr: SocketAddr = raw_addr.parse()?;
     let index = Arc::new(RwLock::new(search::StrictEngine::default()));
-    let store = storage::file::FileStorage::new(dir, index.clone());
+    let store = storage::file::FileStorage::new(dir, index.clone()).await;
 
     println!(
         "Starting server at {}, and serving bindles from {}",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -192,10 +192,10 @@ impl From<RawScaffold> for Scaffold {
 
 /// Returns a file `Store` implementation configured with a temporary directory and strict Search
 /// implementation for use in testing API endpoints
-pub fn setup() -> (FileStorage<StrictEngine>, Arc<RwLock<StrictEngine>>) {
+pub async fn setup() -> (FileStorage<StrictEngine>, Arc<RwLock<StrictEngine>>) {
     let temp = tempdir().expect("unable to create tempdir");
     let index = Arc::new(RwLock::new(StrictEngine::default()));
-    let store = FileStorage::new(temp.path().to_owned(), index.clone());
+    let store = FileStorage::new(temp.path().to_owned(), index.clone()).await;
     (store, index)
 }
 

--- a/tests/v1_api.rs
+++ b/tests/v1_api.rs
@@ -8,7 +8,7 @@ use bindle::storage::Storage;
 #[tokio::test]
 async fn test_successful_workflow() {
     let bindles = common::load_all_files().await;
-    let (store, index) = common::setup();
+    let (store, index) = common::setup().await;
 
     let api = bindle::server::routes::api(store, index);
 
@@ -126,7 +126,7 @@ async fn test_successful_workflow() {
 
 #[tokio::test]
 async fn test_yank() {
-    let (store, index) = common::setup();
+    let (store, index) = common::setup().await;
 
     let api = bindle::server::routes::api(store.clone(), index);
     // Insert an invoice
@@ -181,7 +181,7 @@ async fn test_yank() {
 // test for storage), just the main validation failures from the API
 async fn test_invoice_validation() {
     let bindles = common::load_all_files().await;
-    let (store, index) = common::setup();
+    let (store, index) = common::setup().await;
 
     let api = bindle::server::routes::api(store.clone(), index);
     let valid_raw = bindles.get("valid_v1").expect("Missing scaffold");
@@ -228,7 +228,7 @@ async fn test_invoice_validation() {
 // This isn't meant to test all of the possible validation failures (that should be done in a unit
 // test for storage), just the main validation failures from the API
 async fn test_parcel_validation() {
-    let (store, index) = common::setup();
+    let (store, index) = common::setup().await;
 
     let api = bindle::server::routes::api(store.clone(), index);
     // Insert a parcel
@@ -293,7 +293,7 @@ async fn test_parcel_validation() {
 // functions properly
 async fn test_queries() {
     // Insert data into store
-    let (store, index) = common::setup();
+    let (store, index) = common::setup().await;
 
     let api = bindle::server::routes::api(store.clone(), index);
     let bindles_to_insert = vec!["incomplete", "valid_v1", "valid_v2"];


### PR DESCRIPTION
This warms the search index on startup. So now the search index is ready as soon as the server starts listening for connections.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>