### PR TITLE
ref(client): Refactors CLI to use new client library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,15 +10,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,17 +218,34 @@ checksum = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -553,6 +561,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1068,6 +1085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1228,30 @@ name = "ppv-lite86"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check 0.9.2",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check 0.9.2",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -1666,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1696,10 +1743,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]
@@ -1985,6 +2041,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,6 +2305,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ warp = "0.2"
 bytes = "0.5"
 async-trait = "0.1"
 futures = "0.3"
-clap = "2.33"
+clap = "3.0.0-beta.2"
 reqwest = { version = "0.10", features = ["stream"] }
 hyper = "0.13"
 url = "2.2"

--- a/bin/as2bindle.rs
+++ b/bin/as2bindle.rs
@@ -35,16 +35,16 @@ fn main() {
         .author("DeisLabs at Microsoft Azure")
         .about(DESCRIPTION)
         .arg(
-            Arg::with_name("src")
-                .help("path to directory with package.json")
-                .short("s")
+            Arg::new("src")
+                .about("path to directory with package.json")
+                .short('s')
                 .long("src")
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("bindir")
-                .help("path to bindle directory.")
-                .short("b")
+            Arg::new("bindir")
+                .about("path to bindle directory.")
+                .short('b')
                 .long("bindle")
                 .takes_value(true),
         )

--- a/bin/cargo2bindle.rs
+++ b/bin/cargo2bindle.rs
@@ -37,16 +37,16 @@ fn main() {
         .author("DeisLabs at Microsoft Azure")
         .about(DESCRIPTION)
         .arg(
-            Arg::with_name("cargo")
-                .help("path to directory with cargo.toml")
-                .short("c")
+            Arg::new("cargo")
+                .about("path to directory with cargo.toml")
+                .short('c')
                 .long("cargo")
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("bindir")
-                .help("path to bindle directory.")
-                .short("b")
+            Arg::new("bindir")
+                .about("path to bindle directory.")
+                .short('b')
                 .long("bindle")
                 .takes_value(true),
         )

--- a/bin/client.rs
+++ b/bin/client.rs
@@ -1,4 +1,9 @@
-use clap::{App, Arg, SubCommand};
+use std::path::PathBuf;
+
+use bindle::client::{Client, ClientError, Result};
+use clap::Clap;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::stream::{Stream, StreamExt};
 
 const DESCRIPTION: &str = r#"
 The Bindle Client
@@ -7,78 +12,210 @@ Bindle is a technology for storing and retrieving aggregate applications.
 This program provides tools for working with Bindle servers.
 "#;
 
+#[derive(Clap)]
+#[clap(name = "bindle", version = "0.1.0", author = "DeisLabs at Microsoft Azure", about = DESCRIPTION)]
+struct Opts {
+    #[clap(
+        short = 's',
+        long = "server",
+        env = "BINDLE_SERVER_URL",
+        about = "The address of the bindle server"
+    )]
+    server_url: String,
+    #[clap(subcommand)]
+    subcmd: SubCommand,
+}
+
+#[derive(Clap)]
+enum SubCommand {
+    #[clap(name = "info", about = "get the bindle invoice and display it")]
+    Info(Info),
+    #[clap(
+        name = "push",
+        about = "push a bindle and all its parcels to the server"
+    )]
+    Push(Push),
+    #[clap(name = "get", about = "download the bindle and all its parcels")]
+    Get(Get),
+    #[clap(name = "yank", about = "yank an existing bindle")]
+    Yank(Yank),
+    #[clap(name = "search", about = "search for bindles")]
+    Search(Search),
+    #[clap(
+        name = "get-parcel",
+        about = "get an individual parcel by SHA and store it to a specific location"
+    )]
+    GetParcel(GetParcel),
+    #[clap(
+        name = "get-invoice",
+        about = "get only the specified invoice (does not download parcels) and store it to a specific location"
+    )]
+    GetInvoice(GetInvoice),
+}
+
+#[derive(Clap)]
+struct Info {
+    #[clap(index = 1, value_name = "BINDLE")]
+    bindle_id: String,
+}
+
+#[derive(Clap)]
+struct Push {
+    // TODO: Do we want to take a path to an invoice and a directory containing parcels?
+}
+
+#[derive(Clap)]
+struct Get {
+    #[clap(index = 1, value_name = "BINDLE")]
+    bindle_id: String,
+}
+
+#[derive(Clap)]
+struct Yank {
+    #[clap(index = 1, value_name = "BINDLE")]
+    bindle_id: String,
+}
+
+const VERSION_QUERY: &str = r#"version constraint of the bindle to search for. This is a semver range modifier that can either denote an exact version, or a range of versions.
+
+For example, the range modifier `v=1.0.0-beta.1` indicates that a version MUST match version `1.0.0-beta.1`. Version `1.0.0-beta.12` does NOT match this modifier. 
+
+The range modifiers will include the following modifiers, all based on the Node.js de facto behaviors (found at https://www.npmjs.com/package/semver):
+
+- `<`, `>`, `<=`, `>=`, `=` -- all approximately their mathematical equivalents
+- `-` (`1.2.3 - 1.5.6`) -- range declaration
+- `^` -- patch/minor updates allow (`^1.2.3` would accept `1.2.4` and `1.3.0`)
+- `~` -- at least the given version
+"#;
+
+#[derive(Clap)]
+struct Search {
+    // TODO: Figure out output format (like tables)
+    #[clap(
+        short = 'q',
+        long = "query",
+        about = "name of the bindle to search for, an empty query means all bindles"
+    )]
+    query: Option<String>,
+    #[clap(short = 'b', long = "bindle-version", about = "version constraint of the bindle to search for", long_about = VERSION_QUERY)]
+    version: Option<String>,
+    #[clap(
+        long = "offset",
+        about = "the offset where to start the next page of results"
+    )]
+    offset: Option<u64>,
+    #[clap(long = "limit", about = "the limit of results per page")]
+    limit: Option<u8>,
+    #[clap(
+        long = "strict",
+        about = "whether or not to use strict mode",
+        long_about = "whether or not to use strict mode. Please note that bindle servers must implement a strict mode per the specification, a non-strict (standard) mode is optional"
+    )]
+    strict: Option<bool>,
+    #[clap(
+        long = "yanked",
+        about = "whether or not to include yanked bindles in the search result"
+    )]
+    yanked: Option<bool>,
+}
+
+impl From<Search> for bindle::QueryOptions {
+    fn from(s: Search) -> Self {
+        bindle::QueryOptions {
+            query: s.query,
+            version: s.version,
+            offset: s.offset,
+            limit: s.limit,
+            strict: s.strict,
+            yanked: s.yanked,
+        }
+    }
+}
+
+#[derive(Clap)]
+struct GetParcel {
+    #[clap(index = 1, value_name = "PARCEL_SHA")]
+    sha: String,
+    #[clap(
+        short = 'o',
+        long = "output",
+        default_value = "./parcel.dat",
+        about = "The location where to output the parcel to"
+    )]
+    output: PathBuf,
+}
+
+#[derive(Clap)]
+struct GetInvoice {
+    #[clap(index = 1, value_name = "BINDLE")]
+    bindle_id: String,
+    #[clap(
+        short = 'o',
+        long = "output",
+        default_value = "./invoice.toml",
+        about = "The location where to output the invoice to"
+    )]
+    output: PathBuf,
+}
+
 #[tokio::main]
-async fn main() {
-    let app = App::new("bindle")
-        .version("0.1.0")
-        .author("DeisLabs at Microsoft Azure")
-        .about(DESCRIPTION)
-        .subcommand(
-            SubCommand::with_name("info")
-                .about("get the bindle invoice and display it")
-                .arg(
-                    Arg::with_name("BINDLE")
-                        .help("the bindle to examine")
-                        .required(true),
-                ),
-        )
-        .subcommand(SubCommand::with_name("push").about("push a bindle to the server"))
-        .subcommand(SubCommand::with_name("get").about("download the bindle and all its parcels"))
-        .subcommand(SubCommand::with_name("yank").about("yank an existing bindle"))
-        .subcommand(SubCommand::with_name("search").about("search for bindles"))
-        .subcommand(
-            SubCommand::with_name("invoice-name")
-                .about("display the hashed invoice name for a bindle invoice")
-                .arg(
-                    Arg::with_name("invoice")
-                        .required(true)
-                        .help("the path to the invoice to parse"),
-                ),
-        )
-        .get_matches();
+async fn main() -> std::result::Result<(), ClientError> {
+    let opts = Opts::parse();
 
-    match app.subcommand() {
-        ("info", info) => {
-            let inv = info
-                .map(|i| i.value_of("BINDLE").unwrap_or("NONE"))
-                .unwrap_or("hello");
-            get_invoice(inv).await
+    let bindle_client = Client::new(&opts.server_url)?;
+
+    match opts.subcmd {
+        SubCommand::Info(info_opts) => {
+            let inv = bindle_client.get_invoice(info_opts.bindle_id).await?;
+            tokio::io::stdout().write_all(&toml::to_vec(&inv)?).await?;
         }
-        ("invoice-name", iname) => {
-            let inv = iname
-                .map(|i| i.value_of("invoice").unwrap_or("./invoice.toml"))
-                .unwrap_or("./invoice.toml");
-
-            let invoice_path = std::path::Path::new(inv);
-            let raw = std::fs::read_to_string(invoice_path).expect("File not found");
-            let invoice = toml::from_str::<bindle::Invoice>(raw.as_str()).unwrap();
-            println!("{}", invoice.canonical_name(),)
+        SubCommand::GetInvoice(gi_opts) => {
+            let inv = bindle_client.get_invoice(&gi_opts.bindle_id).await?;
+            tokio::fs::write(&gi_opts.output, &toml::to_vec(&inv)?).await?;
+            println!(
+                "Wrote invoice {} to {}",
+                gi_opts.bindle_id,
+                gi_opts.output.display()
+            );
         }
-        _ => eprintln!("Not implemented"),
+        SubCommand::GetParcel(gp_opts) => get_parcel(bindle_client, gp_opts).await?,
+        SubCommand::Yank(yank_opts) => {
+            bindle_client.yank_invoice(&yank_opts.bindle_id).await?;
+            println!("Bindle {} yanked", yank_opts.bindle_id);
+        }
+        SubCommand::Search(search_opts) => {
+            let matches = bindle_client.query_invoices(search_opts.into()).await?;
+            tokio::io::stdout()
+                .write_all(&toml::to_vec(&matches)?)
+                .await?;
+        }
+        _ => return Err(ClientError::Other("Command unimplemented".to_string())),
     }
+
+    Ok(())
 }
 
-async fn get_invoice(name: &str) {
-    match reqwest::get(to_url(name).as_str()).await {
-        Ok(res) => match res.status() {
-            reqwest::StatusCode::NOT_FOUND => exit(format!("'{}' not found", name)),
-            reqwest::StatusCode::OK => println!(
-                "# request for {}\n{}",
-                name,
-                res.text().await.unwrap_or_else(|_| "ERROR".to_owned())
-            ),
-            _ => exit("Unsupported status"),
-        },
-        Err(err) => exit(err),
+async fn get_parcel(bindle_client: Client, opts: GetParcel) -> Result<()> {
+    let stream = bindle_client.get_parcel_stream(&opts.sha).await?;
+    let file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(&opts.output)
+        .await?;
+    write_stream(stream, file).await?;
+    println!("Wrote parcel {} to {}", opts.sha, opts.output.display());
+    Ok(())
+}
+
+async fn write_stream<S, W>(mut stream: S, mut writer: W) -> Result<()>
+where
+    S: Stream<Item = Result<bytes::Bytes>> + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    while let Some(b) = stream.next().await {
+        let b = b?;
+        writer.write_all(&b).await?;
     }
-}
-
-fn exit<T: std::fmt::Display>(msg: T) {
-    eprintln!("Error: {}", msg);
-    std::process::exit(1)
-}
-
-fn to_url(bindle: &str) -> String {
-    // TODO: How do we want to do this part?
-    format!("http://localhost:8080/v1/_i/{}", bindle)
+    writer.flush().await?;
+    Ok(())
 }

--- a/bin/server.rs
+++ b/bin/server.rs
@@ -18,19 +18,19 @@ async fn main() -> anyhow::Result<()> {
         .author("DeisLabs at Microsoft Azure")
         .about(DESCRIPTION)
         .arg(
-            Arg::with_name("address")
-                .short("i")
+            Arg::new("address")
+                .short('i')
                 .long("address")
                 .value_name("IP_ADDRESS_PORT")
-                .help("the IP address and port to listen on")
+                .about("the IP address and port to listen on")
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("dir")
-                .short("d")
+            Arg::new("dir")
+                .short('d')
                 .long("directory")
                 .value_name("PATH")
-                .help("the path to the directory in which bindles will be stored")
+                .about("the path to the directory in which bindles will be stored")
                 .takes_value(true),
         )
         .get_matches();

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -10,7 +10,7 @@ pub enum ClientError {
     #[error("Invalid configuration: {0}")]
     InvalidConfig(String),
     /// IO errors when reading data from a file
-    #[error("Error while reading file from disk: {0:?}")]
+    #[error("Error while performing IO operation: {0:?}")]
     ReadIo(#[from] std::io::Error),
     /// Invalid TOML parsing that can occur when loading an invoice or label from disk
     #[error("Invalid toml: {0:?}")]

--- a/tests/scaffolds/incomplete/invoice.toml
+++ b/tests/scaffolds/incomplete/invoice.toml
@@ -3,7 +3,7 @@ bindleVersion = "1.0.0"
 [bindle]
 name = "enterprise.com/bridge"
 version = "1.0.0"
-authors = ["Jean-Luc Picard <engage@ufp.com"]
+authors = ["Jean-Luc Picard <engage@ufp.com>"]
 description = "Command deck"
 
 [[parcel]]

--- a/tests/scaffolds/invalid/invoice.toml
+++ b/tests/scaffolds/invalid/invoice.toml
@@ -3,7 +3,7 @@ bindleVersion = "1.0.0"
 [bindle]
 name = "enterprise.com/holodeck"
 # Missing version
-authors = ["Enterprise Engineering <engineering@enterprise.ufp.com"]
+authors = ["Enterprise Engineering <engineering@enterprise.ufp.com>"]
 description = "A diversionary room for those long voyages"
 
 [annotations]

--- a/tests/scaffolds/valid_v1/invoice.toml
+++ b/tests/scaffolds/valid_v1/invoice.toml
@@ -3,7 +3,7 @@ bindleVersion = "1.0.0"
 [bindle]
 name = "enterprise.com/warpcore"
 version = "1.0.0"
-authors = ["Geordi La Forge <mycoolvisor@ufp.com"]
+authors = ["Geordi La Forge <mycoolvisor@ufp.com>"]
 description = "Warp core components"
 
 [annotations]

--- a/tests/scaffolds/valid_v2/invoice.toml
+++ b/tests/scaffolds/valid_v2/invoice.toml
@@ -3,7 +3,7 @@ bindleVersion = "1.0.0"
 [bindle]
 name = "enterprise.com/warpcore"
 version = "2.0.0"
-authors = ["Geordi La Forge <mycoolvisor@ufp.com"]
+authors = ["Geordi La Forge <mycoolvisor@ufp.com>"]
 description = "Warp core components"
 
 [annotations]


### PR DESCRIPTION
This stubs out most of the functionality that we'll need to keep
implementing as we go along. I also updated to clap 3.0 beta so that
we can take advantage of the built in structopt for the client