### PR TITLE
ref(storage): Improves generic constraints on methods that take Ids

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -110,6 +110,12 @@ impl FromStr for Id {
     }
 }
 
+impl From<&Id> for Id {
+    fn from(id: &Id) -> Self {
+        id.clone()
+    }
+}
+
 // Unfortunately I can't do a generic implementation using AsRef<str>/AsRef<Path> due to this issue
 // in Rust with the blanket implementation: https://github.com/rust-lang/rust/issues/50133. So we
 // get _all_ the implementations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ impl Invoice {
     /// produce a slash-delimited "invoice name"
     ///
     /// For example, an invoice with the bindle name "hello" and the bindle version
-    /// "v1.2.3" will produce "hello/v1.2.3"
+    /// "1.2.3" will produce "hello/1.2.3"
     pub fn name(&self) -> String {
         format!("{}/{}", self.bindle.id.name(), self.bindle.id.version())
     }


### PR DESCRIPTION
Now you can actually use an `Id` as an argument to the storage functions