### PR TITLE
switched Invoice struct name from parcels to parcel

### DIFF
--- a/bin/as2bindle.rs
+++ b/bin/as2bindle.rs
@@ -107,7 +107,7 @@ fn main() {
             authors: None,
             description: package.description,
         },
-        parcels: Some(vec![bindle::Parcel {
+        parcel: Some(vec![bindle::Parcel {
             label,
             conditions: None,
         }]),

--- a/bin/cargo2bindle.rs
+++ b/bin/cargo2bindle.rs
@@ -127,13 +127,13 @@ fn main() {
             authors: cargo.package.authors,
             description: cargo.package.description,
         },
-        parcels: None,
+        parcel: None,
         annotations: None,
         group: None,
     };
 
     if !parcels.is_empty() {
-        invoice.parcels = Some(parcels);
+        invoice.parcel = Some(parcels);
     }
 
     // Write invoice

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,14 @@ use search::SearchOptions;
 
 pub const BINDLE_VERSION_1: &str = "v1.0.0";
 
+/// The main structure for a Bindle invoice.
+///
+/// The invoice describes a specific version of a bindle. For example, the bindle
+/// `foo/bar/1.0.0` would be represented as an Invoice with the `BindleSpec` name
+/// set to `foo/bar` and version set to `1.0.0`.
+///
+/// Most fields on this struct are singular to best represent the specification. There,
+/// fields like `group` and `parcel` are singular due to the conventions of TOML.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Invoice {
@@ -28,9 +36,7 @@ pub struct Invoice {
     pub yanked: Option<bool>,
     pub bindle: BindleSpec,
     pub annotations: Option<BTreeMap<String, String>>,
-    #[serde(alias = "parcel")]
-    pub parcels: Option<Vec<Parcel>>,
-    // TODO: Should this be renamed "groups" or should "parcels" be renamed to "parcel"
+    pub parcel: Option<Vec<Parcel>>,
     pub group: Option<Vec<Group>>,
 }
 
@@ -221,7 +227,7 @@ mod test {
                 description: Some("bar".to_owned()),
                 authors: Some(vec!["m butcher".to_owned()]),
             },
-            parcels,
+            parcel: parcels,
             group: None,
         };
 
@@ -234,7 +240,7 @@ mod test {
         assert_eq!(b.description.unwrap().as_str(), "bar");
         assert_eq!(b.authors.unwrap()[0], "m butcher".to_owned());
 
-        let parcels = inv2.parcels.unwrap();
+        let parcels = inv2.parcel.unwrap();
 
         assert_eq!(parcels.len(), 1);
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -303,7 +303,7 @@ mod test {
                 description: Some("bar".to_owned()),
                 authors: Some(vec!["m butcher".to_owned()]),
             },
-            parcels: Some(
+            parcel: Some(
                 labels
                     .iter()
                     .map(|l| crate::Parcel {

--- a/src/storage/file/mod.rs
+++ b/src/storage/file/mod.rs
@@ -179,7 +179,7 @@ impl<T: crate::search::Search + Send + Sync> Storage for FileStorage<T> {
         }
 
         // if there are no parcels, bail early
-        if inv.parcels.is_none() {
+        if inv.parcel.is_none() {
             return Ok(Vec::with_capacity(0));
         }
 
@@ -191,7 +191,7 @@ impl<T: crate::search::Search + Send + Sync> Storage for FileStorage<T> {
         let zero_vec = Vec::with_capacity(0);
         // Loop through the boxes and see what exists
         let missing = inv
-            .parcels
+            .parcel
             .as_ref()
             .unwrap_or(&zero_vec)
             .iter()
@@ -569,7 +569,7 @@ mod test {
             label: label.clone(),
             conditions: None,
         };
-        invoice.parcels = Some(vec![parcel]);
+        invoice.parcel = Some(vec![parcel]);
 
         store
             .create_parcel(&label, &mut data)
@@ -587,7 +587,7 @@ mod test {
             .expect("get the invoice we just stored");
 
         let first_parcel = inv
-            .parcels
+            .parcel
             .expect("parsel vector")
             .pop()
             .expect("got a parcel");

--- a/src/storage/test_common.rs
+++ b/src/storage/test_common.rs
@@ -61,7 +61,7 @@ pub fn invoice_fixture() -> crate::Invoice {
             description: Some("bar".to_owned()),
             authors: Some(vec!["m butcher".to_owned()]),
         },
-        parcels: Some(
+        parcel: Some(
             labels
                 .iter()
                 .map(|l| crate::Parcel {

--- a/tests/v1_api.rs
+++ b/tests/v1_api.rs
@@ -98,7 +98,7 @@ async fn test_successful_workflow() {
     let inv: bindle::Invoice = toml::from_slice(res.body()).expect("should be valid invoice TOML");
 
     // Get a parcel
-    let parcel = &inv.parcels.expect("Should have parcels")[0];
+    let parcel = &inv.parcel.expect("Should have parcels")[0];
     let res = warp::test::request()
         .path(&format!("/v1/_p/{}", parcel.label.sha256))
         .reply(&api)


### PR DESCRIPTION
While working on a NodeJS client, I noticed that packages generated by Bindle were useing `Invoice.parcels` instead of `Invoice.parcel`. This is because I misused the `serde alias` annotation. This PR fixes it.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>