### PR TITLE
feat(*): Adds basic caching support and fetching for the CLI client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "ascii"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +97,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "clap",
+ "dirs",
  "env_logger",
  "futures",
  "hyper 0.13.9",
@@ -110,6 +123,17 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -264,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +316,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg 1.0.1",
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +342,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1467,6 +1528,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1599,18 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64 0.13.0",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,10 @@ authors = ["Matt Butcher <matt.butcher@microsoft.com>"]
 edition = "2018"
 
 [features]
-default = ["server", "client"]
+default = ["server", "client", "caching"]
 server = []
 client = []
+caching = ["client"]
 
 [dependencies]
 anyhow = "1.0"
@@ -35,6 +36,7 @@ hyper = "0.13"
 url = "2.2"
 log = "0.4.11"
 env_logger = "0.8"
+dirs = "3.0"
 
 [dev-dependencies]
 multipart = "0.17"

--- a/src/cache/dumb.rs
+++ b/src/cache/dumb.rs
@@ -1,0 +1,127 @@
+//! A cache that doesn't ever expire entries, generally for use by a client storing bindles on disk
+use std::convert::TryInto;
+
+use log::{info, warn};
+use tokio::io::AsyncRead;
+
+use super::{into_cache_result, Cache};
+use crate::client::Client;
+use crate::storage::{Result, Storage, StorageError};
+use crate::Id;
+
+/// A cache that doesn't ever expire entries. It fills the cache by requesting bindles from a bindle
+/// server using the configured client and stores them in the given storage implementation
+#[derive(Clone)]
+pub struct DumbCache<S: Storage + Clone> {
+    client: Client,
+    inner: S,
+}
+
+impl<S: Storage + Clone> DumbCache<S> {
+    pub fn new(client: Client, store: S) -> DumbCache<S> {
+        DumbCache {
+            client,
+            inner: store,
+        }
+    }
+}
+
+impl<S: Storage + Send + Sync + Clone> Cache for DumbCache<S> {}
+
+#[async_trait::async_trait]
+impl<S: Storage + Send + Sync + Clone> Storage for DumbCache<S> {
+    async fn create_invoice(&self, _: &crate::Invoice) -> Result<Vec<crate::Label>> {
+        Err(StorageError::Other(
+            "This cache implementation does not allow for creation of invoices".to_string(),
+        ))
+    }
+
+    // Load an invoice, even if it is yanked.
+    async fn get_yanked_invoice<I>(&self, id: I) -> Result<crate::Invoice>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<StorageError>,
+    {
+        let parsed_id: Id = id.try_into().map_err(|e| e.into())?;
+        let possible_entry = into_cache_result(self.inner.get_yanked_invoice(&parsed_id).await)?;
+        match possible_entry {
+            Some(inv) => Ok(inv),
+            None => {
+                info!(
+                    "Cache miss for invoice {}, attempting to fetch from server",
+                    parsed_id
+                );
+                let inv = self.client.get_invoice(parsed_id).await?;
+                // Attempt to insert the invoice into the store, if it fails, warn the user and return the invoice anyway
+                if let Err(e) = self.inner.create_invoice(&inv).await {
+                    warn!("Fetched invoice from server, but encountered error when trying to save to local store: {:?}", e);
+                }
+                Ok(inv)
+            }
+        }
+    }
+
+    async fn yank_invoice<I>(&self, id: I) -> Result<()>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<StorageError>,
+    {
+        // This is just an update of the local cache
+        self.inner.yank_invoice(id).await
+    }
+
+    async fn create_parcel<R: AsyncRead + Unpin + Send + Sync>(
+        &self,
+        _: &crate::Label,
+        _: &mut R,
+    ) -> Result<()> {
+        Err(StorageError::Other(
+            "This cache implementation does not allow for creation of parcels".to_string(),
+        ))
+    }
+
+    async fn get_parcel(&self, parcel_id: &str) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
+        let possible_entry = into_cache_result(self.inner.get_parcel(parcel_id).await)?;
+        match possible_entry {
+            Some(parcel) => Ok(parcel),
+            None => {
+                info!(
+                    "Cache miss for parcel {}, attempting to fetch from server",
+                    parcel_id
+                );
+                // TODO: I don't like faking the rest of the data outside of the SHA. We should
+                // figure out a nice way to return that metadata in the client (perhaps as a
+                // separate tuple than contains metadata and the stream)
+                let label = crate::Label {
+                    sha256: parcel_id.to_owned(),
+                    name: "".to_string(),
+                    size: 0,
+                    media_type: "*/*".to_string(),
+                    annotations: None,
+                };
+                let stream = self.client.get_parcel_stream(parcel_id).await?;
+                // Attempt to insert the parcel into the store, if it fails, warn the user and
+                // return the parcel anyway. Either way, we need to refetch the stream, since it has
+                // been read after we try to insert
+                let stream = match self
+                    .inner
+                    .create_parcel(&label, &mut crate::stream_util::BodyReadBuffer(stream))
+                    .await
+                {
+                    Ok(_) => return self.inner.get_parcel(parcel_id).await,
+                    Err(e) => {
+                        warn!("Fetched parcel from server, but encountered error when trying to save to local store: {:?}", e);
+                        self.client.get_parcel_stream(parcel_id).await?
+                    }
+                };
+                Ok(Box::new(crate::stream_util::BodyReadBuffer(stream)))
+            }
+        }
+    }
+
+    async fn get_label(&self, _: &str) -> Result<crate::Label> {
+        Err(StorageError::Other(
+            "This cache implementation does not allow for fetching labels".to_string(),
+        ))
+    }
+}

--- a/src/cache/lru.rs
+++ b/src/cache/lru.rs
@@ -1,0 +1,5 @@
+//! A least recently used cache implementation
+
+/// A least recently used cache implementation
+// TODO: Actually implement
+pub struct LruCache {}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,0 +1,28 @@
+//! Caching implementations for client and server-side usage. This module is under heavy development
+//! and iteration
+
+use crate::storage::{Storage, StorageError};
+
+pub mod dumb;
+pub use dumb::DumbCache;
+
+pub mod lru;
+pub use lru::LruCache;
+
+/// A marker trait that indicates this is a caching implementation (as opposed to just storage)
+pub trait Cache: Storage {}
+
+/// A custom result type representing a possible cache miss. As all underlying caches implement
+/// `Storage`, this contains a storage error that is guaranteed not to be a cache miss (e.g.
+/// NotFound). The Option indicates whether a value was returned. This value is obtained by
+/// coverting a normal storage result using `into_cache_result`
+pub(crate) type CacheResult<T> = Result<Option<T>, crate::storage::StorageError>;
+
+/// Converts a storage result into a `CacheResult`
+pub(crate) fn into_cache_result<T>(res: crate::storage::Result<T>) -> CacheResult<T> {
+    match res {
+        Ok(val) => Ok(Some(val)),
+        Err(e) if matches!(e, StorageError::NotFound) => Ok(None),
+        Err(e) => Err(e),
+    }
+}

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -9,7 +9,7 @@ pub enum ClientError {
     /// Invalid configuration was given to the client
     #[error("Invalid configuration: {0}")]
     InvalidConfig(String),
-    /// IO errors when reading data from a file
+    /// IO errors from interacting with the file system
     #[error("Error while performing IO operation: {0:?}")]
     Io(#[from] std::io::Error),
     /// Invalid TOML parsing that can occur when loading an invoice or label from disk
@@ -59,4 +59,11 @@ pub enum ClientError {
     /// issue
     #[error("{0}")]
     Other(String),
+}
+
+impl From<std::convert::Infallible> for ClientError {
+    fn from(_: std::convert::Infallible) -> Self {
+        // Doesn't matter what we return as Infallible cannot happen
+        ClientError::Other("Shouldn't happen".to_string())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![macro_use]
 extern crate serde;
 
+#[cfg(feature = "caching")]
+pub mod cache;
 #[cfg(feature = "client")]
 pub mod client;
 pub mod id;
@@ -8,6 +10,7 @@ pub mod search;
 #[cfg(feature = "server")]
 pub mod server;
 pub mod storage;
+pub(crate) mod stream_util;
 
 pub use id::Id;
 pub use search::Matches;
@@ -19,7 +22,7 @@ use std::collections::BTreeMap;
 
 use search::SearchOptions;
 
-pub const BINDLE_VERSION_1: &str = "v1.0.0";
+pub const BINDLE_VERSION_1: &str = "1.0.0";
 
 /// The main structure for a Bindle invoice.
 ///

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,0 +1,110 @@
+use serde::{Deserialize, Serialize};
+
+mod noop;
+mod strict;
+
+pub use noop::NoopEngine;
+pub use strict::StrictEngine;
+
+#[derive(Debug)]
+/// The search options for performing this query and returning results
+pub struct SearchOptions {
+    /// The offset from the last search results
+    pub offset: u64,
+    /// The maximum number of results to return
+    pub limit: u8,
+    /// Whether to use strict mode (if there are multiple modes supported)
+    pub strict: bool,
+    /// Whether to return yanked bindles
+    pub yanked: bool,
+}
+
+impl Default for SearchOptions {
+    fn default() -> Self {
+        SearchOptions {
+            offset: 0,
+            limit: 50,
+            strict: false,
+            yanked: false,
+        }
+    }
+}
+
+/// Describes the matches that are returned
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Matches {
+    /// The query used to find this match set
+    pub query: String,
+    /// Whether the search engine used strict mode
+    pub strict: bool,
+    /// The offset of the first result in the matches
+    pub offset: u64,
+    /// The maximum number of results this query would have returned
+    pub limit: u8,
+    /// The total number of matches the search engine located
+    ///
+    /// In many cases, this will not match the number of results returned on this query
+    pub total: u64,
+    /// Whether there are more results than the ones returned here
+    pub more: bool,
+    /// Whether this list includes potentially yanked invoices
+    pub yanked: bool,
+    /// The list of invoices returned as this part of the query
+    ///
+    /// The length of this Vec will be less than or equal to the limit.
+    // This needs to go at the bottom otherwise the table serialization in TOML gets weird. See
+    // https://github.com/alexcrichton/toml-rs/issues/258
+    pub invoices: Vec<crate::Invoice>,
+}
+
+impl Matches {
+    fn new(opts: &SearchOptions, query: String) -> Self {
+        Matches {
+            // Assume options are definitive.
+            query,
+            strict: opts.strict,
+            offset: opts.offset,
+            limit: opts.limit,
+            yanked: opts.yanked,
+
+            // Defaults
+            invoices: vec![],
+            more: false,
+            total: 0,
+        }
+    }
+}
+
+/// This trait describes the minimal set of features a Bindle provider must implement to provide
+/// query support. Implementors of this trait should handle any locking of the internal index in
+/// their implementation
+#[async_trait::async_trait]
+pub trait Search {
+    /// A high-level function that can take raw search strings (queries and filters) and options.
+    ///
+    /// This will parse the terms and filters according to its internal rules, and return
+    /// a set of matches.
+    ///
+    /// An error is returned if either there is something incorrect in the terms/filters,
+    /// or if the search engine itself fails to process the query.
+    async fn query(
+        &self,
+        term: String,
+        filter: String,
+        options: SearchOptions,
+    ) -> anyhow::Result<Matches>;
+
+    /// Given an invoice, extract information from it that will be useful for searching.
+    ///
+    /// This high-level feature does not provide any guarantees about how it will
+    /// process the invoice. But it may implement Strict and/or Standard modes
+    /// described in the protocol specification.
+    ///
+    /// If the index function is given an invoice it has already indexed, it treats
+    /// the call as an update. Otherwise, it adds a new entry to the index.
+    ///
+    /// As a special note, if an invoice is yanked, the index function will mark it
+    /// as such, following the protocol specification's requirements for yanked
+    /// invoices.
+    async fn index(&self, document: &crate::Invoice) -> anyhow::Result<()>;
+}

--- a/src/search/noop.rs
+++ b/src/search/noop.rs
@@ -1,0 +1,23 @@
+//! A no-op query engine implementation. Useful for use in storage engines being used in caches
+
+use crate::search::{Matches, Search, SearchOptions};
+
+/// A no-op query engine implementation. Its methods always returns `Ok` with an empty result
+#[derive(Default, Clone)]
+pub struct NoopEngine {}
+
+#[async_trait::async_trait]
+impl Search for NoopEngine {
+    async fn query(
+        &self,
+        term: String,
+        _filter: String,
+        options: SearchOptions,
+    ) -> anyhow::Result<Matches> {
+        Ok(Matches::new(&options, term))
+    }
+
+    async fn index(&self, _: &crate::Invoice) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/src/search/strict.rs
+++ b/src/search/strict.rs
@@ -1,113 +1,13 @@
+//! A strict query engine implementation. It always expects a strict match of query terms
+
 use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use log::trace;
-use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
-#[derive(Debug)]
-/// The search options for performing this query and returning results
-pub struct SearchOptions {
-    /// The offset from the last search results
-    pub offset: u64,
-    /// The maximum number of results to return
-    pub limit: u8,
-    /// Whether to use strict mode (if there are multiple modes supported)
-    pub strict: bool,
-    /// Whether to return yanked bindles
-    pub yanked: bool,
-}
-
-impl Default for SearchOptions {
-    fn default() -> Self {
-        SearchOptions {
-            offset: 0,
-            limit: 50,
-            strict: false,
-            yanked: false,
-        }
-    }
-}
-
-/// Describes the matches that are returned
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Matches {
-    /// The query used to find this match set
-    pub query: String,
-    /// Whether the search engine used strict mode
-    pub strict: bool,
-    /// The offset of the first result in the matches
-    pub offset: u64,
-    /// The maximum number of results this query would have returned
-    pub limit: u8,
-    /// The total number of matches the search engine located
-    ///
-    /// In many cases, this will not match the number of results returned on this query
-    pub total: u64,
-    /// Whether there are more results than the ones returned here
-    pub more: bool,
-    /// Whether this list includes potentially yanked invoices
-    pub yanked: bool,
-    /// The list of invoices returned as this part of the query
-    ///
-    /// The length of this Vec will be less than or equal to the limit.
-    // This needs to go at the bottom otherwise the table serialization in TOML gets weird. See
-    // https://github.com/alexcrichton/toml-rs/issues/258
-    pub invoices: Vec<crate::Invoice>,
-}
-
-impl Matches {
-    fn new(opts: &SearchOptions, query: String) -> Self {
-        Matches {
-            // Assume options are definitive.
-            query,
-            strict: opts.strict,
-            offset: opts.offset,
-            limit: opts.limit,
-            yanked: opts.yanked,
-
-            // Defaults
-            invoices: vec![],
-            more: false,
-            total: 0,
-        }
-    }
-}
-
-/// This trait describes the minimal set of features a Bindle provider must implement to provide
-/// query support. Implementors of this trait should handle any locking of the internal index in
-/// their implementation
-#[async_trait::async_trait]
-pub trait Search {
-    /// A high-level function that can take raw search strings (queries and filters) and options.
-    ///
-    /// This will parse the terms and filters according to its internal rules, and return
-    /// a set of matches.
-    ///
-    /// An error is returned if either there is something incorrect in the terms/filters,
-    /// or if the search engine itself fails to process the query.
-    async fn query(
-        &self,
-        term: String,
-        filter: String,
-        options: SearchOptions,
-    ) -> anyhow::Result<Matches>;
-
-    /// Given an invoice, extract information from it that will be useful for searching.
-    ///
-    /// This high-level feature does not provide any guarantees about how it will
-    /// process the invoice. But it may implement Strict and/or Standard modes
-    /// described in the protocol specification.
-    ///
-    /// If the index function is given an invoice it has already indexed, it treats
-    /// the call as an update. Otherwise, it adds a new entry to the index.
-    ///
-    /// As a special note, if an invoice is yanked, the index function will mark it
-    /// as such, following the protocol specification's requirements for yanked
-    /// invoices.
-    async fn index(&self, document: &crate::Invoice) -> anyhow::Result<()>;
-}
+use crate::search::{Matches, Search, SearchOptions};
 
 /// Implements strict query processing.
 #[derive(Clone)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,8 +4,6 @@ mod reply;
 
 pub mod routes;
 
-pub(crate) mod stream_util;
-
 use std::net::SocketAddr;
 
 use super::storage::Storage;


### PR DESCRIPTION
Note that I only implemented the cache part for the new subcommand.
I'll add caching to the other commands in a follow up PR. There are
a bunch of code changes here. Most of them were "campfire rule" cleanup
as I found some bugs and inconsistencies, as well as some restructuring
to make things cleaner