### PR TITLE
docs(*): Cleans up docs for crate publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ caching = ["client"]
 test-tools = ["multipart"]
 cli = ["clap"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 anyhow = "1.0"
 toml = "0.5"

--- a/src/async_util.rs
+++ b/src/async_util.rs
@@ -11,9 +11,10 @@ use sha2::{Digest, Sha256};
 use tokio::io::AsyncRead;
 use tokio::stream::Stream;
 
-/// A wrapper around a Warp stream of bytes that implements AsyncRead. This might no longer be
-/// necessary once we hit tokio 0.3 and upgrade tokio-util. Tokio util has a StreamReader wrapper we
-/// can use, but there might still be some conversion stuff to deal with
+/// A wrapper around a Warp stream of bytes that implements AsyncRead.
+///
+/// This might no longer be necessary once we hit tokio 0.3 and upgrade tokio-util. Tokio util has a
+/// StreamReader wrapper we can use, but there might still be some conversion stuff to deal with
 pub struct BodyReadBuffer<B, T, E>(pub T)
 where
     B: Buf,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -19,6 +19,7 @@ use crate::Id;
 
 pub use error::ClientError;
 
+/// A shorthand `Result` type that always uses `ClientError` as its error variant
 pub type Result<T> = std::result::Result<T, ClientError>;
 
 const INVOICE_ENDPOINT: &str = "_i";
@@ -27,6 +28,7 @@ const QUERY_ENDPOINT: &str = "_q";
 const RELATIONSHIP_ENDPOINT: &str = "_r";
 const TOML_MIME_TYPE: &str = "application/toml";
 
+/// A client type for interacting with a Bindle server
 #[derive(Clone)]
 pub struct Client {
     client: HttpClient,

--- a/src/id.rs
+++ b/src/id.rs
@@ -21,7 +21,9 @@ type Result<T> = std::result::Result<T, ParseError>;
 const PATH_SEPARATOR: char = '/';
 
 /// A parsed representation of an ID string for a bindle. This is currently defined as an arbitrary
-/// path with a version string at the end. Examples of valid ID strings include:
+/// path with a version string at the end.
+///
+/// Examples of valid ID strings include:
 ///
 /// - `foo/0.1.0`
 /// - `example.com/foo/1.2.3`
@@ -73,7 +75,7 @@ impl Id {
     /// would impose both naming constraints on the bindle and security issues on the
     /// storage layout. So this function hashes the name/version data (which together
     /// MUST be unique in the system) and uses the resulting hash as the canonical
-    /// name. The hash is guaranteed to be in the character set [a-zA-Z0-9].
+    /// name. The hash is guaranteed to be in the character set `[a-zA-Z0-9]`.
     pub fn sha(&self) -> String {
         let mut hasher = Sha256::new();
         hasher.update(&self.name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod testing;
 
 #[doc(inline)]
 pub use id::Id;
+#[doc(inline)]
 pub use search::Matches;
 
 use semver::{Compat, Version, VersionReq};
@@ -34,6 +35,7 @@ use std::collections::BTreeMap;
 
 use search::SearchOptions;
 
+/// The version string for the v1 Bindle Spec
 pub const BINDLE_VERSION_1: &str = "1.0.0";
 
 /// The main structure for a Bindle invoice.

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -32,7 +32,7 @@ impl Default for SearchOptions {
     }
 }
 
-/// Describes the matches that are returned
+/// Describes the matches that are returned from a query
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Matches {
     /// The query used to find this match set
@@ -78,8 +78,11 @@ impl Matches {
 }
 
 /// This trait describes the minimal set of features a Bindle provider must implement to provide
-/// query support. Implementors of this trait should handle any locking of the internal index in
-/// their implementation
+/// query support.
+///
+/// Implementors of this trait should handle any locking of the internal index in their
+/// implementation Please note that due to this being an `async_trait`, the types might look
+/// complicated. Look at the code directly to see the simpler function signatures for implementation
 #[async_trait::async_trait]
 pub trait Search {
     /// A high-level function that can take raw search strings (queries and filters) and options.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -16,6 +16,10 @@ use crate::Id;
 /// A custom shorthand result type that always has an error type of [`StorageError`](StorageError)
 pub type Result<T> = core::result::Result<T, StorageError>;
 
+/// The basic functionality required for bindle to use something as a storage engine.
+///
+/// Please note that due to this being an `async_trait`, the types might look complicated. Look at
+/// the code directly to see the simpler function signatures for implementation
 #[async_trait::async_trait]
 pub trait Storage {
     /// This takes an invoice and creates it in storage.

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,11 +1,12 @@
 //! Some helpful utilities for testing. This module is only available if the `test-tools` feature is
-//! enabled. Its main feature is allowing the use of prebuilt scaffolds for testing. See the
-//! [README](https://github.com/deislabs/bindle/blob/master/tests/scaffolds/README.md) in the
-//! testing directory of bindle for more information on scaffolding structure. All loading functions
-//! will load scaffolds by default from `$CARGO_MANIFEST_DIR/tests/scaffolds`. However, this
-//! directory can be configured by setting the `BINDLE_SCAFFOLD_DIR` environment variable to your
-//! desired path. All functions will panic if they encounter an error to make it easier on users (so
-//! they don't have to handle the errors in their tests in the exact same way)
+//! enabled. Its main feature is allowing the use of prebuilt scaffolds for testing.
+//!
+//! See the [README](https://github.com/deislabs/bindle/blob/master/tests/scaffolds/README.md) in
+//! the testing directory of bindle for more information on scaffolding structure. All loading
+//! functions will load scaffolds by default from `$CARGO_MANIFEST_DIR/tests/scaffolds`. However,
+//! this directory can be configured by setting the `BINDLE_SCAFFOLD_DIR` environment variable to
+//! your desired path. All functions will panic if they encounter an error to make it easier on
+//! users (so they don't have to handle the errors in their tests in the exact same way)
 
 use std::collections::HashMap;
 use std::io::Read;


### PR DESCRIPTION
I built the docs locally to make sure everything looked ok and fixed
issues as I went along