### PR TITLE
fix(client): Fixes missing HTTP code mapping

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -291,6 +291,7 @@ async fn unwrap_status(resp: reqwest::Response, endpoint: Endpoint) -> Result<re
     match (resp.status(), endpoint) {
         (StatusCode::OK, _) => Ok(resp),
         (StatusCode::ACCEPTED, Endpoint::Invoice) => Ok(resp),
+        (StatusCode::CREATED, Endpoint::Invoice) => Ok(resp),
         (StatusCode::NOT_FOUND, Endpoint::Invoice) | (StatusCode::FORBIDDEN, Endpoint::Invoice) => {
             Err(ClientError::InvoiceNotFound)
         }


### PR DESCRIPTION
Right now the client will return an error if an invoice is created
that already has all of its parcels. This adds the missing HTTP code
mapping to fix that issue.