### PR TITLE
feat(*): Subpathed parcels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,12 +28,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "ascii"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97be891acc47ca214468e09425d02cef3af2c94d0d82081cd02061f996802f14"
-
-[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,16 +63,6 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
-
-[[package]]
-name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -100,11 +84,10 @@ dependencies = [
  "dirs",
  "env_logger",
  "futures",
- "hyper 0.13.9",
- "log 0.4.11",
- "mime 0.3.16",
- "mime_guess 2.0.3",
- "multipart",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
  "reqwest",
  "semver",
  "serde",
@@ -115,7 +98,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
- "url 2.2.0",
+ "url",
  "warp",
 ]
 
@@ -217,25 +200,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "chunked_transfer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
 
 [[package]]
 name = "clap"
@@ -378,7 +342,7 @@ checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.11",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -417,7 +381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -553,7 +517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -566,12 +530,6 @@ dependencies = [
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
-
-[[package]]
-name = "groupable"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 
 [[package]]
 name = "h2"
@@ -610,7 +568,7 @@ dependencies = [
  "bytes",
  "headers-core",
  "http",
- "mime 0.3.16",
+ "mime",
  "sha-1 0.8.2",
  "time",
 ]
@@ -683,25 +641,6 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
-dependencies = [
- "base64 0.9.3",
- "httparse",
- "language-tags",
- "log 0.3.9",
- "mime 0.2.6",
- "num_cpus",
- "time",
- "traitobject",
- "typeable",
- "unicase 1.4.2",
- "url 1.7.2",
-]
-
-[[package]]
-name = "hyper"
 version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
@@ -731,21 +670,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
  "bytes",
- "hyper 0.13.9",
+ "hyper",
  "native-tls",
  "tokio",
  "tokio-tls",
-]
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -794,22 +722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
-name = "iron"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d308ca2d884650a8bf9ed2ff4cb13fbb2207b71f64cda11dc9b892067295e8"
-dependencies = [
- "hyper 0.10.16",
- "log 0.3.9",
- "mime_guess 1.8.8",
- "modifier",
- "num_cpus",
- "plugin",
- "typemap",
- "url 1.7.2",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,12 +747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,15 +757,6 @@ name = "libc"
 version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.11",
-]
 
 [[package]]
 name = "log"
@@ -884,30 +781,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "mime"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-dependencies = [
- "log 0.3.9",
-]
-
-[[package]]
-name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "mime_guess"
-version = "1.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216929a5ee4dd316b1702eedf5e74548c123d370f47841ceaac38ca154690ca3"
-dependencies = [
- "mime 0.2.6",
- "phf",
- "phf_codegen",
- "unicase 1.4.2",
-]
 
 [[package]]
 name = "mime_guess"
@@ -915,8 +791,8 @@ version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
- "mime 0.3.16",
- "unicase 2.6.0",
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -931,7 +807,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.11",
+ "log",
  "miow 0.2.2",
  "net2",
  "slab",
@@ -944,7 +820,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
- "log 0.4.11",
+ "log",
  "mio",
  "miow 0.3.6",
  "winapi 0.3.9",
@@ -984,12 +860,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "modifier"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
-
-[[package]]
 name = "multipart"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,28 +867,14 @@ checksum = "8209c33c951f07387a8497841122fc6f712165e3f9bda3e6be4645b58188f676"
 dependencies = [
  "buf_redux",
  "httparse",
- "hyper 0.10.16",
- "iron",
- "log 0.4.11",
- "mime 0.3.16",
- "mime_guess 2.0.3",
- "nickel",
+ "log",
+ "mime",
+ "mime_guess",
  "quick-error",
  "rand 0.6.5",
  "safemem",
  "tempfile",
- "tiny_http",
  "twoway",
-]
-
-[[package]]
-name = "mustache"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51956ef1c5d20a1384524d91e616fb44dfc7d8f249bf696d49c97dd3289ecab5"
-dependencies = [
- "log 0.3.9",
- "serde",
 ]
 
 [[package]]
@@ -1029,7 +885,7 @@ checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.11",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -1048,46 +904,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "nickel"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5061a832728db2dacb61cefe0ce303b58f85764ec680e71d9138229640a46d9"
-dependencies = [
- "groupable",
- "hyper 0.10.16",
- "lazy_static",
- "log 0.3.9",
- "modifier",
- "mustache",
- "plugin",
- "regex",
- "serde",
- "serde_json",
- "time",
- "typemap",
- "url 1.7.2",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg 1.0.1",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1159,12 +975,6 @@ checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-
-[[package]]
-name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
@@ -1176,45 +986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
-]
-
-[[package]]
-name = "phf"
-version = "0.7.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.7.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.7.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
-dependencies = [
- "phf_shared",
- "rand 0.6.5",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.7.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
-dependencies = [
- "siphasher",
- "unicase 1.4.2",
 ]
 
 [[package]]
@@ -1282,15 +1053,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
-name = "plugin"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
-dependencies = [
- "typemap",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,7 +1068,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -1317,7 +1079,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -1569,22 +1331,22 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper 0.13.9",
+ "hyper",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.11",
- "mime 0.3.16",
- "mime_guess 2.0.3",
+ "log",
+ "mime",
+ "mime_guess",
  "native-tls",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite 0.2.0",
  "serde",
  "serde_urlencoded 0.7.0",
  "tokio",
  "tokio-tls",
- "url 2.2.0",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1625,7 +1387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
  "base64 0.12.3",
- "log 0.4.11",
+ "log",
  "ring",
  "sct",
  "webpki",
@@ -1751,7 +1513,7 @@ dependencies = [
  "dtoa",
  "itoa",
  "serde",
- "url 2.2.0",
+ "url",
 ]
 
 [[package]]
@@ -1812,12 +1574,6 @@ checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "slab"
@@ -1933,19 +1689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny_http"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1661fa0a44c95d01604bd05c66732a446c657efb62b5164a7a083a3b552b4951"
-dependencies = [
- "ascii",
- "chrono",
- "chunked_transfer",
- "log 0.4.11",
- "url 1.7.2",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,7 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
 dependencies = [
  "futures-util",
- "log 0.4.11",
+ "log",
  "pin-project 0.4.27",
  "tokio",
  "tungstenite",
@@ -2039,7 +1782,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log 0.4.11",
+ "log",
  "pin-project-lite 0.1.11",
  "tokio",
 ]
@@ -2066,7 +1809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.11",
+ "log",
  "pin-project-lite 0.2.0",
  "tracing-core",
 ]
@@ -2091,12 +1834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,10 +1851,10 @@ dependencies = [
  "http",
  "httparse",
  "input_buffer",
- "log 0.4.11",
+ "log",
  "rand 0.7.3",
  "sha-1 0.9.2",
- "url 2.2.0",
+ "url",
  "utf-8",
 ]
 
@@ -2128,21 +1865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "typeable"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
-
-[[package]]
-name = "typemap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
-dependencies = [
- "unsafe-any",
 ]
 
 [[package]]
@@ -2159,20 +1881,11 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-dependencies = [
- "version_check 0.1.5",
-]
-
-[[package]]
-name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -2212,30 +1925,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
-dependencies = [
- "traitobject",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
 
 [[package]]
 name = "url"
@@ -2244,9 +1937,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.0",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2275,12 +1968,6 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-
-[[package]]
-name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
@@ -2291,7 +1978,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.11",
+ "log",
  "try-lock",
 ]
 
@@ -2305,10 +1992,10 @@ dependencies = [
  "futures",
  "headers",
  "http",
- "hyper 0.13.9",
- "log 0.4.11",
- "mime 0.3.16",
- "mime_guess 2.0.3",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
  "multipart",
  "pin-project 0.4.27",
  "scoped-tls",
@@ -2356,7 +2043,7 @@ checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default = ["server", "client", "caching", "test-tools"]
 server = ["warp"]
 client = ["reqwest", "mime_guess", "dirs"]
 caching = ["client"]
-test-tools = ["multipart"]
+test-tools = []
 cli = ["clap"]
 
 [package.metadata.docs.rs]
@@ -64,7 +64,6 @@ log = "0.4.11"
 env_logger = "0.8"
 dirs = { version = "3.0", optional = true }
 mime_guess = { version = "2.0", optional = true }
-multipart = { version = "0.17", optional = true }
 
 [dev-dependencies]
 mime = "0.3"

--- a/README.md
+++ b/README.md
@@ -95,12 +95,10 @@ A bindle is composed of several parts:
 
 - The _invoice_ (`invoice.toml`) contains information about the bindle (`name`, `description`...)
   as well as a manifest of parcels (individual data items).
-- A _parcel_ contains two parts:
-  - The _label_ (`label.toml`) that contains data about the parcel
-  - the _parcel contents_ (`box.dat`) that contains the opaque data ("what's in the box")
+- A _parcel_ has a (`parcel.dat`) that contains the opaque and arbitrary data
 
 A _bindle hub_ is a service that manages storage and retrieval of bindles. It is available
-via an HTTP/3 connection (almost always over TLS). A hub supports the following actions:
+via an HTTP/2 connection (almost always over TLS). A hub supports the following actions:
 
 - GET: Get a bindle and any of its parcels that you don't currently have
 - POST: Push a bindle and any of its parcels that the hub currently doesn't have

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -63,7 +63,7 @@ pub enum SubCommand {
     GetInvoice(GetInvoice),
     #[clap(
         name = "generate-label",
-        about = "generates a label.toml for the given file"
+        about = "generates a label for the given file and prints it to stdout. This can be used to generate the label and add it to an invoice"
     )]
     GenerateLabel(GenerateLabel),
 }
@@ -175,7 +175,9 @@ impl From<Search> for bindle::QueryOptions {
 
 #[derive(Clap)]
 pub struct GetParcel {
-    #[clap(index = 1, value_name = "PARCEL_SHA")]
+    #[clap(index = 1, value_name = "BINDLE_ID")]
+    pub bindle_id: bindle::Id,
+    #[clap(index = 2, value_name = "PARCEL_SHA")]
     pub sha: String,
     #[clap(
         short = 'o',
@@ -210,13 +212,6 @@ pub struct GenerateLabel {
     #[clap(index = 1, value_name = "FILE")]
     pub path: PathBuf,
     #[clap(
-        short = 'o',
-        long = "output",
-        default_value = "./label.toml",
-        about = "The file where to output the label to"
-    )]
-    pub output: PathBuf,
-    #[clap(
         short = 'n',
         long = "name",
         about = "the name of the parcel, defaults to the name + extension of the file"
@@ -238,7 +233,9 @@ pub struct PushInvoice {
 
 #[derive(Clap)]
 pub struct PushFile {
-    #[clap(index = 1, value_name = "FILE")]
+    #[clap(index = 1, value_name = "BINDLE_ID")]
+    pub bindle_id: bindle::Id,
+    #[clap(index = 2, value_name = "FILE")]
     pub path: PathBuf,
     #[clap(
         short = 'n',

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -14,7 +14,6 @@ BINDIR/
   |       |- invoice.toml
   |- parcels/
       |- PARCEL_SHA
-         |- label.toml
          |- parcel.dat
 ```
 

--- a/docs/label-spec.md
+++ b/docs/label-spec.md
@@ -1,6 +1,6 @@
 # Label Specification
 
-A _label_ (`label.toml`) contains metadata about a box. It is in TOML format, and is considered immutable once stored.
+A _label_ contains metadata about a parcel. It is in TOML format and exists only in the `parcel` array of an invoice
 
 ```toml
 sha256 = 5b992e90b71d5fadab3cd3777230ef370df75f5b...

--- a/docs/parcel-spec.md
+++ b/docs/parcel-spec.md
@@ -1,12 +1,7 @@
 # The Parcel Specification
 
-A parcel consists of two parts:
-
-- a `label.toml` which contains information about what is in the parcel
-- a `parcel.dat` which contains opaque parcel data. This file is not inspected by Bindle
+A parcel consists of a single `parcel.dat`, which contains opaque parcel data. This file is not inspected by Bindle
 
 A parcel is immutable. Once it is written to a Bindle server, it cannot be altered at all.
-
-The Bindle server MAY modify the `label.toml` at write-time if incomplete or incorrect data is supplied. For example, the file size of the `parcel.dat` may be overwritten. But the `parcel.dat` itself must be immutable.
 
 The `parcel.dat` files SHOULD be stored in read-only mode.

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -5,17 +5,16 @@ Bindle uses HTTP/2 with TLS as a transport protocol. All bodies and responses ex
 The HTTP endpoints defined above MAY exist as a subpath on a server, or in the server's root. For example, `https://example.com/v1/_i/foo` and `https://example.com/_i/foo` are both legal paths for the specification below. However, `https://example.com/_i/v1/foo` is not (or, rather, it is a legal URI for a package named `v1/foo`).
 
 HTTP Endpoints:
-- `/_i/{bindle-name}`: The path to a bindle's invoice. Note that {bindle-name} can be pathy. For example, `/_i/example.com/mybindle/1.2.3` is a valid path to a bindle named `example.com/mybindle/1.2.3`.
+- `/_i/{bindle-name}`: The path to a bindle's invoice. Note that `{bindle-name}` can be pathy. For example, `/_i/example.com/mybindle/1.2.3` is a valid path to a bindle named `example.com/mybindle/1.2.3`.
     - `GET`: Get a bindle by name. This returns an invoice object.
     - `HEAD`: Send just the headers of a GET request
     - `DELETE`: Yank a bindle. This will set the `yank` field on a bindle to `true`. This is the only mutation allowed on a Bindle.
 - `/_i`
     - `POST`: Create a new bindle, optionally also sending some or all of the parcels. If all of the parcels specified in the bindle exist, a 201 status will be returned. If 1 or more of the parcels are missing, a 202 status will be returned with a reference to the missing parcels
-- `/_p/{parcel-id}`: The path to a parcel ID, where `{parcel-id}` is an exact SHA to a parcel.
+- `/_i/{bindle-name}@{parcel-id}`: The path to a Bindle name and parcel ID, where `{parcel-id}` is an exact SHA of a parcel and `{bindle-name}` follows the same rules as outlined above. Parcels can only be accessed if the client has the proper permissions to access the given bindle and, as such, cannot be accessed directly
     - `GET`: Directly fetch a parcel's opaque data.
     - `HEAD`: Send just the headers of a GET request
-- `/_p`
-    - `POST`: Create a parcel if it does not already exist. This may be disallowed. This MUST post both the label and the parcel data with a `multipart/form-data` content type, with the label data as the first part in the request
+    - `POST`: Create a parcel if it does not already exist. This may be disallowed. The data included in the body must have the same SHA as indicated by the `{parcel-id}` and must exist within the invoice
 - `/_q`: The query endpoint
 - `/_r`: The relationships endpoint. This endpoint allows for querying of various relationships between parts of a bindle.
     - `/_r/missing/{bindle-name}`: An endpoint for retrieving missing parcels in a bindle. `{bindle-name}` follows the same aforementioned rules around bindle naming

--- a/docs/standalone-bindle-spec.md
+++ b/docs/standalone-bindle-spec.md
@@ -28,7 +28,7 @@ A standalone Bindle MAY be compressed into a `.tar.gz` file (i.e. tarball). Howe
 
 Items in a standalone Bindle MAY be sent to a Bindle server. Implementations SHOULD first create the invoice and use the returned list of missing parcels (if there are any) to selectively send only the needed parcels to the Bindle server. This is recommended to avoid consuming bandwidth while possibly sending large amounts of data to the bindle server that isn't needed.
 
-In cases where the invoice already exists, implementations SHOULD take advantage of the `HEAD` HTTP method on the parcel (`/_p`) endpoint to check if the parcel already exists before uploading. This is recommended to avoid consuming bandwidth while possibly sending large amounts of data to the bindle server that isn't needed.
+In cases where the invoice already exists, implementations SHOULD take advantage of the relationships (`/_r`) endpoint to check if the parcel already exists before uploading. This is recommended to avoid consuming bandwidth while possibly sending large amounts of data to the bindle server that isn't needed.
 
 ## Additional Notes
 

--- a/src/client/load.rs
+++ b/src/client/load.rs
@@ -9,18 +9,13 @@ use tokio::fs::File;
 use tokio::stream::Stream;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
-/// Loads a file as an async `Stream`, returning the stream, and the length of the file (for use in
-/// setting the content-length in the multipart form). Used primarily for streaming parcel data to a
-/// bindle server
+/// Loads a file as an async `Stream`, returning the stream, and the SHA256 sum of the file. Used
+/// primarily for streaming parcel data to a bindle server
 pub async fn raw<P: AsRef<Path>>(
     file_path: P,
-) -> Result<(
-    impl Stream<Item = std::result::Result<bytes::BytesMut, Error>>,
-    u64,
-)> {
+) -> Result<impl Stream<Item = std::result::Result<bytes::BytesMut, Error>>> {
     let file = File::open(file_path).await?;
-    let size = file.metadata().await?.len();
-    Ok((FramedRead::new(file, BytesCodec::new()), size))
+    Ok(FramedRead::new(file, BytesCodec::new()))
 }
 
 /// Loads a file and deserializes it from TOML to an arbirary type. Turbofish may be required to

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -58,23 +58,27 @@ pub trait Storage {
         I: TryInto<Id> + Send,
         I::Error: Into<StorageError>;
 
-    /// Creates a parcel with the associated label data. The parcel can be anything that implements
+    /// Creates a parcel with the associated sha. The parcel can be anything that implements
     /// `Stream`
-    async fn create_parcel<R, B>(&self, label: &super::Label, data: &mut R) -> Result<()>
+    async fn create_parcel<R, B>(&self, parcel_id: &str, data: &mut R) -> Result<()>
     where
         R: Stream<Item = std::io::Result<B>> + Unpin + Send + Sync,
         B: bytes::Buf;
 
     /// Get a specific parcel using its SHA
-    async fn get_parcel(
+    async fn get_parcel<I>(
         &self,
+        bindle_id: I,
         parcel_id: &str,
-    ) -> Result<Box<dyn Stream<Item = Result<bytes::Bytes>> + Unpin + Send + Sync>>;
+    ) -> Result<Box<dyn Stream<Item = Result<bytes::Bytes>> + Unpin + Send + Sync>>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<StorageError>;
 
-    /// Get the label for a parcel
+    /// Checks if the given parcel exists in storage.
     ///
-    /// This reads the label from storage and then parses it into a Label object.
-    async fn get_label(&self, parcel_id: &str) -> Result<crate::Label>;
+    /// This should not load the full parcel from storage but only indicate if the parcel exists
+    async fn parcel_exists(&self, parcel_id: &str) -> Result<bool>;
 }
 
 /// StorageError describes the possible error states when storing and retrieving bindles.

--- a/tests/scaffolds/README.md
+++ b/tests/scaffolds/README.md
@@ -8,14 +8,11 @@ complete bindle. That directory is structured like so:
 <DIRNAME>
 ├── invoice.toml
 └── parcels
-    ├── first.toml
     ├── first.dat
-    ├── second.toml
     └── second.dat
 ```
 
 The `invoice.toml` file should contain the invoice, and the parcels directory should contain all of
-the parcels you want to create that are connected to that invoice. Each parcel should have a
-`<parcel_name>.toml` file containing the `Label` and an opaque `<parcel_name>.dat` file that
-contains the actual data to be uploaded for the parcel. If the `parcels` directory is non-existent,
-it will assume there are no parcels to upload.
+the parcels you want to create that are connected to that invoice. Each parcel should have an opaque
+`<parcel_name>.dat` file that contains the actual data to be uploaded for the parcel. If the
+`parcels` directory is non-existent, it will assume there are no parcels to upload.

--- a/tests/scaffolds/invalid/invoice.toml
+++ b/tests/scaffolds/invalid/invoice.toml
@@ -2,18 +2,12 @@ bindleVersion = "1.0.0"
 
 [bindle]
 name = "enterprise.com/holodeck"
-# Missing version
+version = "1.0.0"
 authors = ["Enterprise Engineering <engineering@enterprise.ufp.com>"]
 description = "A diversionary room for those long voyages"
 
 [annotations]
 broken = "yes"
-
-[[parcel]]
-label.sha256 = "e1706ab0a39ac88094b6d54a3f5cdba41fe5a901"
-label.mediaType = "text/plain"
-label.name = "safety_protocols.txt"
-label.size = 12345
 
 [[parcel]]
 label.sha256 = "e1706ab0a39ac88094b6d54a3f5cdba41fe5a901"

--- a/tests/scaffolds/invalid/parcels/invalid_sha.toml
+++ b/tests/scaffolds/invalid/parcels/invalid_sha.toml
@@ -1,5 +1,0 @@
-# Not a real sha
-sha256 = "e1706ab0a39ac88094b6d54a3f5cdba41fe5a901"
-mediaType = "text/plain"
-name = "moriarty.txt"
-size = 20

--- a/tests/scaffolds/invalid/parcels/missing.dat
+++ b/tests/scaffolds/invalid/parcels/missing.dat
@@ -1,1 +1,0 @@
-yeah, they don't work most of the time

--- a/tests/scaffolds/invalid/parcels/missing.toml
+++ b/tests/scaffolds/invalid/parcels/missing.toml
@@ -1,4 +1,0 @@
-sha256 = "e1706ab0a39ac88094b6d54a3f5cdba41fe5a901"
-mediaType = "text/plain"
-name = "safety_protocols.txt"
-# Missing size

--- a/tests/scaffolds/lotsa_parcels/parcels/barrel.toml
+++ b/tests/scaffolds/lotsa_parcels/parcels/barrel.toml
@@ -1,4 +1,0 @@
-sha256 = "51534027079925942fdea13d4d088c7126f3e456364525b67d6ca0858d6587bc"
-mediaType = "text/plain"
-name = "barrel.txt"
-size = 15

--- a/tests/scaffolds/lotsa_parcels/parcels/crate.toml
+++ b/tests/scaffolds/lotsa_parcels/parcels/crate.toml
@@ -1,4 +1,0 @@
-sha256 = "a6e41416c2bee47e9b97900ba57de696cccc1920e331f5a0d490726a7938d8c6"
-mediaType = "text/plain"
-name = "crate.txt"
-size = 14

--- a/tests/scaffolds/lotsa_parcels/parcels/parcel.toml
+++ b/tests/scaffolds/lotsa_parcels/parcels/parcel.toml
@@ -1,4 +1,0 @@
-sha256 = "23f310b54076878fd4c36f0c60ec92011a8b406349b98dd37d08577d17397de5"
-mediaType = "text/plain"
-name = "isolinear_chip.txt"
-size = 9

--- a/tests/scaffolds/valid_v1/parcels/parcel.toml
+++ b/tests/scaffolds/valid_v1/parcels/parcel.toml
@@ -1,4 +1,0 @@
-sha256 = "23f310b54076878fd4c36f0c60ec92011a8b406349b98dd37d08577d17397de5"
-mediaType = "text/plain"
-name = "isolinear_chip.txt"
-size = 9

--- a/tests/scaffolds/valid_v2/invoice.toml
+++ b/tests/scaffolds/valid_v2/invoice.toml
@@ -10,6 +10,12 @@ description = "Warp core components"
 engineering_location = "main"
 
 [[parcel]]
+label.sha256 = "23f310b54076878fd4c36f0c60ec92011a8b406349b98dd37d08577d17397de5"
+label.mediaType = "text/plain"
+label.name = "isolinear_chip.txt"
+label.size = 9
+
+[[parcel]]
 label.sha256 = "5e244f1c791ee45ec9cc02b281e3b58524e757561e9dc39cdd7ec0f4d328a3d3"
 label.mediaType = "text/plain"
 label.name = "isolinear_chip_v2.txt"

--- a/tests/scaffolds/valid_v2/parcels/other.dat
+++ b/tests/scaffolds/valid_v2/parcels/other.dat
@@ -1,0 +1,1 @@
+a red one

--- a/tests/scaffolds/valid_v2/parcels/parcel.toml
+++ b/tests/scaffolds/valid_v2/parcels/parcel.toml
@@ -1,4 +1,0 @@
-sha256 = "5e244f1c791ee45ec9cc02b281e3b58524e757561e9dc39cdd7ec0f4d328a3d3"
-mediaType = "text/plain"
-name = "isolinear_chip_v2.txt"
-size = 11


### PR DESCRIPTION
This refactors parcel access to occur on the bindle object it is associated
with rather than bare links to parcels. This was a fairly large change as
it had to be reflected both in the storage and client, as well as anything
that consumed them