### PR TITLE
feat(*): Adds new proxy provider

### DIFF
--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -204,14 +204,14 @@ async fn get_all<C: Cache + Send + Sync + Clone>(cache: C, opts: Get) -> Result<
                 Err(e) => {
                     match e {
                         ProviderError::NotFound => warn!("Parcel {} does not exist", sha),
-                        ProviderError::CacheError(err)
+                        ProviderError::ProxyError(err)
                             if matches!(err, ClientError::ParcelNotFound) =>
                         {
                             warn!("Parcel {} does not exist", sha)
                         }
                         // Only return an error if it isn't a not found error. By design, an invoice
                         // can contain parcels that don't yet exist
-                        ProviderError::CacheError(inner) => return Err(inner),
+                        ProviderError::ProxyError(inner) => return Err(inner),
                         _ => {
                             return Err(ClientError::Other(format!(
                                 "Unable to get parcel {}: {:?}",
@@ -248,7 +248,7 @@ async fn get_all<C: Cache + Send + Sync + Clone>(cache: C, opts: Get) -> Result<
 fn map_storage_error(e: ProviderError) -> ClientError {
     match e {
         ProviderError::Io(e) => ClientError::Io(e),
-        ProviderError::CacheError(inner) => inner,
+        ProviderError::ProxyError(inner) => inner,
         _ => ClientError::Other(format!("{:?}", e)),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod cache;
 pub mod client;
 mod id;
 pub mod provider;
+#[cfg(feature = "client")]
+pub mod proxy;
 pub mod search;
 #[cfg(feature = "server")]
 pub mod server;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,0 +1,116 @@
+//! A proxy provider implementation that forwards all requests to another server using the Bindle
+//! client. This requires the `client` feature to be enabled
+
+use std::convert::TryInto;
+
+use reqwest::StatusCode;
+use tokio::stream::{Stream, StreamExt};
+
+use crate::client::{Client, ClientError};
+use crate::provider::{Provider, ProviderError, Result};
+use crate::Id;
+
+#[derive(Clone)]
+pub struct Proxy {
+    client: Client,
+}
+
+impl Proxy {
+    pub fn new(client: Client) -> Self {
+        Proxy { client }
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for Proxy {
+    async fn create_invoice(&self, inv: &crate::Invoice) -> Result<Vec<crate::Label>> {
+        let res = self.client.create_invoice(inv.to_owned()).await?;
+        Ok(res.missing.unwrap_or_default())
+    }
+
+    async fn get_yanked_invoice<I>(&self, id: I) -> Result<crate::Invoice>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<ProviderError>,
+    {
+        // Parse the ID now because the error type constraint doesn't match that of the client
+        let parsed_id = id.try_into().map_err(|e| e.into())?;
+        self.client
+            .get_yanked_invoice(parsed_id)
+            .await
+            .map_err(|e| e.into())
+    }
+
+    async fn yank_invoice<I>(&self, id: I) -> Result<()>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<ProviderError>,
+    {
+        // Parse the ID now because the error type constraint doesn't match that of the client
+        let parsed_id = id.try_into().map_err(|e| e.into())?;
+        self.client
+            .yank_invoice(parsed_id)
+            .await
+            .map_err(|e| e.into())
+    }
+
+    async fn create_parcel<I, R, B>(&self, bindle_id: I, parcel_id: &str, data: R) -> Result<()>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<ProviderError>,
+        R: Stream<Item = std::io::Result<B>> + Unpin + Send + Sync + 'static,
+        B: bytes::Buf,
+    {
+        // Parse the ID now because the error type constraint doesn't match that of the client
+        let parsed_id = bindle_id.try_into().map_err(|e| e.into())?;
+        self.client
+            .create_parcel_from_stream(parsed_id, parcel_id, data)
+            .await
+            .map_err(|e| e.into())
+    }
+
+    async fn get_parcel<I>(
+        &self,
+        bindle_id: I,
+        parcel_id: &str,
+    ) -> Result<Box<dyn Stream<Item = Result<bytes::Bytes>> + Unpin + Send + Sync>>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<ProviderError>,
+    {
+        // Parse the ID now because the error type constraint doesn't match that of the client
+        let parsed_id = bindle_id.try_into().map_err(|e| e.into())?;
+        let stream = self.client.get_parcel_stream(parsed_id, parcel_id).await?;
+        Ok(Box::new(stream.map(|res| res.map_err(|e| e.into()))))
+    }
+
+    async fn parcel_exists<I>(&self, bindle_id: I, parcel_id: &str) -> Result<bool>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<ProviderError>,
+    {
+        let parsed_id = bindle_id.try_into().map_err(|e| e.into())?;
+        let resp = self
+            .client
+            .raw(
+                reqwest::Method::HEAD,
+                &format!(
+                    "{}/{}@{}",
+                    crate::client::INVOICE_ENDPOINT,
+                    parsed_id,
+                    parcel_id,
+                ),
+                None::<reqwest::Body>,
+            )
+            .await
+            .map_err(|e| ProviderError::Other(e.to_string()))?;
+        match resp.status() {
+            StatusCode::OK => Ok(true),
+            StatusCode::NOT_FOUND => Ok(false),
+            _ => Err(ProviderError::ProxyError(ClientError::InvalidRequest {
+                status_code: resp.status(),
+                message: None,
+            })),
+        }
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -332,8 +332,9 @@ mod test {
             .expect("Unable to insert invoice into store");
         store
             .create_parcel(
+                &scaffold.invoice.bindle.id,
                 &parcel.sha,
-                &mut FramedRead::new(data, BytesCodec::default()),
+                FramedRead::new(data, BytesCodec::default()),
             )
             .await
             .expect("Unable to create parcel");
@@ -500,8 +501,9 @@ mod test {
         let parcel_data = std::io::Cursor::new(parcel.data.clone());
         store
             .create_parcel(
+                &scaffold.invoice.bindle.id,
                 &parcel.sha,
-                &mut FramedRead::new(parcel_data, BytesCodec::default()),
+                FramedRead::new(parcel_data, BytesCodec::default()),
             )
             .await
             .expect("Unable to create parcel");

--- a/src/server/reply.rs
+++ b/src/server/reply.rs
@@ -62,7 +62,7 @@ pub fn into_reply(error: ProviderError) -> warp::reply::WithStatus<Toml> {
         | ProviderError::InvalidId => StatusCode::BAD_REQUEST,
         ProviderError::Yanked => StatusCode::FORBIDDEN,
         #[cfg(feature = "caching")]
-        ProviderError::CacheError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        ProviderError::ProxyError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         ProviderError::Other(_) | ProviderError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
     };
 


### PR DESCRIPTION
This is a simple proxy provider that forwards requests to a bindle server. It
also necessitated changes to the provider API to account for proxying. The
only part of it I am not completely sure about is the `'static` bound I had
to add. I _think_ it makes sense as we need to make sure the stream lives long
enough, but I am not sure if there could be a better way.