### PR TITLE
fix(server): Remove reference to reqwest

### DIFF
--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -12,8 +12,8 @@ pub mod v1 {
     use super::*;
 
     use crate::QueryOptions;
-    use reqwest::Method;
     use tokio_stream::{self as stream, StreamExt};
+    use warp::http::Method;
 
     const PARCEL_ID_SEPARATOR: char = '@';
 


### PR DESCRIPTION
This reference was causing build failures when only using the `server` feature as we don't import reqwest for that