### PR TITLE
fix(provider): Fixes race condition with file provider

### DIFF
--- a/src/server/reply.rs
+++ b/src/server/reply.rs
@@ -55,7 +55,7 @@ pub fn into_reply(error: ProviderError) -> warp::reply::WithStatus<Toml> {
             error = ProviderError::NotFound;
             StatusCode::NOT_FOUND
         }
-        ProviderError::Exists => StatusCode::CONFLICT,
+        ProviderError::Exists | ProviderError::WriteInProgress => StatusCode::CONFLICT,
         ProviderError::Malformed(_)
         | ProviderError::Unserializable(_)
         | ProviderError::DigestMismatch


### PR DESCRIPTION
The file provider had a possible race condition where 2 people try to create
the same file or if someone tries to create and read at the same time. This
resolves that by writing first to a "part" file and then renaming it. It also
adds documentation to the provider trait that terminal providers should take
care to handle atomic operations or locking