### PR TITLE
added library support for yanked signature and keyring

### DIFF
--- a/bin/as2bindle.rs
+++ b/bin/as2bindle.rs
@@ -88,6 +88,7 @@ async fn main() {
     let mut invoice = bindle::Invoice {
         bindle_version: bindle::BINDLE_VERSION_1.to_owned(),
         yanked: None,
+        yanked_signature: None,
         bindle: bindle::BindleSpec {
             id: format!("{}/{}", package.name, package.version)
                 .parse()

--- a/bin/cargo2bindle.rs
+++ b/bin/cargo2bindle.rs
@@ -121,6 +121,7 @@ async fn main() {
     let mut invoice = bindle::Invoice {
         bindle_version: bindle::BINDLE_VERSION_1.to_owned(),
         yanked: None,
+        yanked_signature: None,
         bindle: bindle::BindleSpec {
             id: format!("{}/{}", cargo.package.name, cargo.package.version)
                 .parse()

--- a/docs/signing-spec.md
+++ b/docs/signing-spec.md
@@ -416,10 +416,10 @@ to do directly with creator intent. (In other words, the creator is not the auth
 A compromised host could yank all packages, which may have dire initial consequences.
 However, these consequences are probably the correct consequences when a compromise happens, as the result is a denial of service from the host to the agent.
 
-A `yanked` field and the `yanked_signature` could both be removed by a malicious `host`, which would allow a rollback attack.
+A `yanked` field and the `yankedSignature` could both be removed by a malicious `host`, which would allow a rollback attack.
 There is currently not a mitigation from this. (Compromised hosts can also remove regular signature blocks, effectively rendering a signed bindle unsigned.)
 
-> As with regular signature blocks, `yanked_signature` is append-only. When a `host` rotates its keys, it SHOULD append a new `yanked_signature` block, but it MUST NOT remove the old `yanked_signature` block.
+> As with regular signature blocks, `yankedSignature` is append-only. When a `host` rotates its keys, it SHOULD append a new `yankedSignature` block, but it MUST NOT remove the old `yankedSignature` block.
 
 ### Possible Alternatives to Yank Signing
 

--- a/docs/signing-spec.md
+++ b/docs/signing-spec.md
@@ -217,24 +217,25 @@ A keyring is an annotated list of (public) keys that can be used for verifying s
 The keyring format is expressed as TOML here:
 
 ```toml
+version = "1.0"
 
 [[key]]
 label = "Matt Butcher <technosophos@example.com>"
 roles = ["creator", "approver"]
 key = "aa453q4..."
-label_signature = "dsaff678..."
+labelSignature = "dsaff678..."
 
 [[key]]
 label = "Brigade pipeline at builder.example.com"
 roles = ["proxy"]
 key = "bb453q4..."
-label_signature = "dsaff678..."
+labelSignature = "dsaff678..."
 
 [[key]]
 label = "https://bindle.example.com"
 roles = ["host"]
 key = "cc453q4..."
-label_signature = "dsaff678..."
+labelSignature = "dsaff678..."
 ```
 
 Fields on the `[[key]]` object:
@@ -242,7 +243,7 @@ Fields on the `[[key]]` object:
 - `label`: A human-readable label that hints what this key is for
 - `roles`: A list of roles that the user has granted to the key
 - `key`: The base64-encoded public key for this label
-- `label_signature`: A signature block for the label, to assert that the label is the same one that was intended by the key creator (optional, may be removed)
+- `labelSignature`: A signature block for the label, to assert that the label is the same one that was intended by the key creator (optional, may be removed)
 
 ## Reading Signatures as Provenance
 

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -51,7 +51,7 @@ pub type AnnotationMap = BTreeMap<String, String>;
 pub struct Invoice {
     pub bindle_version: String,
     pub yanked: Option<bool>,
-    pub yanked_signature: Option<Signature>,
+    pub yanked_signature: Option<Vec<Signature>>,
     pub bindle: BindleSpec,
     pub annotations: Option<AnnotationMap>,
     pub parcel: Option<Vec<Parcel>>,

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -51,6 +51,7 @@ pub type AnnotationMap = BTreeMap<String, String>;
 pub struct Invoice {
     pub bindle_version: String,
     pub yanked: Option<bool>,
+    pub yanked_signature: Option<Signature>,
     pub bindle: BindleSpec,
     pub annotations: Option<AnnotationMap>,
     pub parcel: Option<Vec<Parcel>>,
@@ -468,6 +469,7 @@ mod test {
             },
             parcel: parcels,
             yanked: None,
+            yanked_signature: None,
             annotations: None,
             group: None,
             signature: None,

--- a/src/invoice/signature.rs
+++ b/src/invoice/signature.rs
@@ -1,9 +1,13 @@
 //! Contains the Signature type along with associated types and Roles
 
+use ed25519_dalek::{Keypair, Signer};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
+
+/// The latest key ring version supported by this library.
+pub const KEY_RING_VERSION: &str = "1.0";
 
 /// A signature describes a cryptographic signature of the parcel list.
 ///
@@ -58,6 +62,7 @@ pub enum SignatureRole {
     Creator,
     Proxy,
     Host,
+    Approver,
 }
 
 impl Display for SignatureRole {
@@ -69,7 +74,84 @@ impl Display for SignatureRole {
                 Self::Creator => "creator",
                 Self::Proxy => "proxy",
                 Self::Host => "host",
+                Self::Approver => "approver",
             }
         )
+    }
+}
+
+/// A KeyRing contains a list of public keys.
+///
+/// The purpose of this keyring is to validate signatures. The keyring NEVER
+/// contains private keys.
+///
+/// The concepts are described in the signing-spec.md document for Bindle.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyRing {
+    pub version: String,
+    pub key: Vec<KeyEntry>,
+}
+
+impl Default for KeyRing {
+    fn default() -> Self {
+        Self {
+            version: KEY_RING_VERSION.to_owned(),
+            key: vec![],
+        }
+    }
+}
+
+/// A KeyEntry describes an entry on a keyring.
+///
+/// An entry has a key, an identifying label, a list of roles, and an optional signature of this data.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyEntry {
+    /// The human-friendly name of the key.
+    ///
+    /// This has no particular security importance. It is just for convenience and
+    /// can be changed by the user who owns this keyring.
+    pub label: String,
+    /// The list of roles, where a role is one of the signature roles.
+    pub roles: Vec<SignatureRole>,
+    /// The public key, encoded as the platform dictates.
+    ///
+    /// As of this writing, a key is a base64-encoded Ed25519 public key.
+    pub key: String,
+    /// A signed version of the label
+    ///
+    /// The specification provides an optional field for signing the label with a known
+    /// private key as a way of protecting labels against tampering.
+    pub label_signature: Option<String>,
+}
+
+impl KeyEntry {
+    pub fn sign_label(&mut self, key: Keypair) {
+        let sig = key.sign(self.label.as_bytes());
+        self.label_signature = Some(base64::encode(sig.to_bytes()));
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ed25519_dalek::Keypair;
+
+    #[test]
+    fn test_sign_label() {
+        let mut rng = rand::rngs::OsRng {};
+        let keypair = Keypair::generate(&mut rng);
+
+        let mut ke = KeyEntry {
+            label: "Matt Butcher <matt@example.com>".to_owned(),
+            key: "jTtZIzQCfZh8xy6st40xxLwxVw++cf0C0cMH3nJBF+c=".to_owned(),
+            roles: vec![SignatureRole::Host],
+            label_signature: None,
+        };
+
+        ke.sign_label(keypair);
+
+        assert!(ke.label_signature.is_some());
     }
 }

--- a/src/search/strict.rs
+++ b/src/search/strict.rs
@@ -185,6 +185,7 @@ mod test {
         Invoice {
             bindle_version: crate::BINDLE_VERSION_1.to_owned(),
             yanked: None,
+            yanked_signature: None,
             annotations: None,
             bindle: crate::BindleSpec {
                 id: format!("{}/{}", name, version).parse().unwrap(),


### PR DESCRIPTION
This brings the current signature library into parity with the current signing spec.

- Adds yanked_signature
- Adds keyring
- Adds key entry
- Adds key entry signing
- Fixes a snake_case typo in the spec

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>