### PR TITLE
added a verify_label function to the key entry

### DIFF
--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -181,6 +181,10 @@ impl Invoice {
                     let cleartext = self.cleartext(s.by.clone(), s.role.clone());
 
                     // Verify the signature
+                    // TODO: This would allow a trivial DOS attack in which an attacker
+                    // would only need to attach a known-bad signature, and that would
+                    // prevent the module from ever being usable. This is marginally
+                    // better if we only verify signatures on known keys.
                     self.verify_signature(&s, cleartext.as_bytes())?;
 
                     // See if the public key is known to us

--- a/src/invoice/signature.rs
+++ b/src/invoice/signature.rs
@@ -134,10 +134,12 @@ impl KeyEntry {
     }
     pub fn verify_label(self, key: PublicKey) -> anyhow::Result<()> {
         match self.label_signature {
-            // If there is no label signature, then I guess we say everything's good.
-            None => Ok(()),
+            None => {
+                log::info!("Label was not signed. Skipping.");
+                Ok(())
+            }
             Some(txt) => {
-                let decoded_txt = base64::decode(txt.as_bytes())?;
+                let decoded_txt = base64::decode(txt)?;
                 let sig = EdSignature::new(decoded_txt.as_slice().try_into()?);
                 key.verify_strict(self.label.as_bytes(), &sig)?;
                 Ok(())

--- a/src/invoice/signature.rs
+++ b/src/invoice/signature.rs
@@ -1,9 +1,10 @@
 //! Contains the Signature type along with associated types and Roles
 
-use ed25519_dalek::{Keypair, Signer};
+use ed25519_dalek::{Keypair, PublicKey, Signature as EdSignature, Signer};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use std::convert::TryInto;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// The latest key ring version supported by this library.
@@ -131,6 +132,18 @@ impl KeyEntry {
         let sig = key.sign(self.label.as_bytes());
         self.label_signature = Some(base64::encode(sig.to_bytes()));
     }
+    pub fn verify_label(self, key: PublicKey) -> anyhow::Result<()> {
+        match self.label_signature {
+            // If there is no label signature, then I guess we say everything's good.
+            None => Ok(()),
+            Some(txt) => {
+                let decoded_txt = base64::decode(txt.as_bytes())?;
+                let sig = EdSignature::new(decoded_txt.as_slice().try_into()?);
+                key.verify_strict(self.label.as_bytes(), &sig)?;
+                Ok(())
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -150,8 +163,11 @@ mod test {
             label_signature: None,
         };
 
+        let pubkey = keypair.public;
         ke.sign_label(keypair);
 
         assert!(ke.label_signature.is_some());
+
+        ke.verify_label(pubkey).expect("verification failed");
     }
 }


### PR DESCRIPTION
This is an addition to the Keyring code, adding a way to verify that the label on a key entry has not been tampered with.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>