### PR TITLE
Add CLI command to create keyfile.

### DIFF
--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -1,7 +1,8 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use bindle::client::{Client, ClientError, Result};
+use bindle::invoice::signature::{SecretKeyEntry, SecretKeyFile};
 use bindle::provider::ProviderError;
 use bindle::standalone::{StandaloneRead, StandaloneWrite};
 use bindle::{
@@ -107,6 +108,50 @@ async fn main() -> std::result::Result<(), ClientError> {
             )
             .await?;
             println!("{}", toml::to_string_pretty(&label)?);
+        }
+        SubCommand::CreateKey(create_opts) => {
+            let dir = create_opts.secret_file.unwrap_or_else(|| {
+                default_config_dir()
+                    .unwrap_or_else(|| PathBuf::from("."))
+                    .join("secret_keys.toml")
+            });
+            println!("Writing keys to {}", dir.to_string_lossy());
+
+            match std::fs::metadata(dir.clone()) {
+                Err(_) => {
+                    println!(
+                        "File {} does not exist. Creating it.",
+                        dir.to_string_lossy()
+                    );
+                    let mut keyfile = SecretKeyFile::default();
+                    let newkey = SecretKeyEntry::new(
+                        create_opts.label,
+                        vec![bindle::SignatureRole::Creator],
+                    );
+                    keyfile.key.push(newkey);
+                    keyfile
+                        .save_file(dir)
+                        .map_err(|e| ClientError::Other(e.to_string()))?;
+                }
+                Ok(info) => {
+                    if !info.is_file() {
+                        eprint!("Path must point to a file.");
+                        return Err(ClientError::Other(
+                            "Keyfile cannot be directory or symlink".to_owned(),
+                        ));
+                    }
+                    let mut keyfile = SecretKeyFile::load_file(dir.clone())
+                        .map_err(|e| ClientError::Other(e.to_string()))?;
+                    let newkey = SecretKeyEntry::new(
+                        create_opts.label,
+                        vec![bindle::SignatureRole::Creator],
+                    );
+                    keyfile.key.push(newkey);
+                    keyfile
+                        .save_file(dir)
+                        .map_err(|e| ClientError::Other(e.to_string()))?;
+                }
+            }
         }
     }
 
@@ -263,4 +308,8 @@ fn map_storage_error(e: ProviderError) -> ClientError {
         ProviderError::ProxyError(inner) => inner,
         _ => ClientError::Other(format!("{:?}", e)),
     }
+}
+
+fn default_config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|v| v.join("bindle"))
 }

--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -151,7 +151,7 @@ async fn main() -> std::result::Result<(), ClientError> {
                         .await
                         .map_err(|e| ClientError::Other(e.to_string()))?;
                 }
-                Err(e) => return Err(ClientError::Other(e.to_string())),
+                Err(e) => return Err(e.into()),
             }
         }
     }

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -66,6 +66,11 @@ pub enum SubCommand {
         about = "generates a label for the given file and prints it to stdout. This can be used to generate the label and add it to an invoice"
     )]
     GenerateLabel(GenerateLabel),
+    #[clap(
+        name = "create-key",
+        about = "creates a new signing key and places it in the local secret keys. If no secret file is provided, this will store in the default config directory for Bindle. The LABEL is typically a name and email addres, of the form 'name <email>'."
+    )]
+    CreateKey(CreateKey),
 }
 
 #[derive(Clap)]
@@ -223,6 +228,22 @@ pub struct GenerateLabel {
         about = "the media (mime) type of the file. If not provided, the tool will attempt to guess the mime type. If guessing fails, the default is `application/octet-stream`"
     )]
     pub media_type: Option<String>,
+}
+
+#[derive(Clap)]
+pub struct CreateKey {
+    #[clap(
+        index = 1,
+        value_name = "LABEL",
+        about = "The name of the key, such as 'Matt <me@example.com>'"
+    )]
+    pub label: String,
+    #[clap(
+        short = 'f',
+        long = "secrets-file",
+        about = "the path to the file where secrets should be stored. If it does not exist, it will be created. If it does exist, the key will be appened."
+    )]
+    pub secret_file: Option<PathBuf>,
 }
 
 #[derive(Clap)]

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -68,7 +68,7 @@ pub enum SubCommand {
     GenerateLabel(GenerateLabel),
     #[clap(
         name = "create-key",
-        about = "creates a new signing key and places it in the local secret keys. If no secret file is provided, this will store in the default config directory for Bindle. The LABEL is typically a name and email addres, of the form 'name <email>'."
+        about = "creates a new signing key and places it in the local secret keys. If no secret file is provided, this will store in the default config directory for Bindle. The LABEL is typically a name and email address, of the form 'name <email>'."
     )]
     CreateKey(CreateKey),
 }
@@ -241,7 +241,7 @@ pub struct CreateKey {
     #[clap(
         short = 'f',
         long = "secrets-file",
-        about = "the path to the file where secrets should be stored. If it does not exist, it will be created. If it does exist, the key will be appened."
+        about = "the path to the file where secrets should be stored. If it does not exist, it will be created. If it does exist, the key will be appended."
     )]
     pub secret_file: Option<PathBuf>,
 }

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -7,7 +7,7 @@ mod condition;
 mod group;
 mod label;
 mod parcel;
-mod signature;
+pub mod signature;
 
 #[doc(inline)]
 pub use api::{ErrorResponse, InvoiceCreateResponse, MissingParcelsResponse, QueryOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! client and a server implementation, along with various other utilities
 
 mod id;
-mod invoice;
+pub mod invoice;
 
 pub mod async_util;
 #[cfg(feature = "caching")]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -213,6 +213,28 @@ async fn test_get_invoice() {
 }
 
 #[tokio::test]
+async fn test_create_key() {
+    let tempdir = tempfile::tempdir().expect("Unable to set up tempdir");
+    let cmd = format!(
+        "run --features cli --bin bindle -- create-key testkey -f {}",
+        tempdir.path().join("testkey.toml").to_str().unwrap()
+    );
+    let output = std::process::Command::new("cargo")
+        .args(cmd.split(' '))
+        .env("BINDLE_SERVER_URL", "localhost:8080")
+        .output()
+        .expect("Key should get created");
+    assert_status(output, "Key should be generated");
+    assert!(
+        tokio::fs::metadata(tempdir.path().join("testkey.toml"))
+            .await
+            .expect("Unable to read keyfile")
+            .is_file(),
+        "Expected key file"
+    )
+}
+
+#[tokio::test]
 async fn test_get_parcel() {
     let controller = TestController::new().await;
     setup_data(&controller.client).await;


### PR DESCRIPTION
Add support for creating and reading keyfiles. Adds `bindle create-key` command.

Closes #103

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>