### PR TITLE
add sign-invoice command

### DIFF
--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -2,7 +2,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use bindle::client::{Client, ClientError, Result};
-use bindle::invoice::signature::{SecretKeyEntry, SecretKeyFile};
+use bindle::invoice::signature::{Keypair, SecretKeyEntry, SecretKeyFile, SignatureRole};
+use bindle::invoice::Invoice;
 use bindle::provider::ProviderError;
 use bindle::standalone::{StandaloneRead, StandaloneWrite};
 use bindle::{
@@ -90,6 +91,34 @@ async fn main() -> std::result::Result<(), ClientError> {
                 .create_invoice_from_file(push_opts.path)
                 .await?;
             println!("Invoice {} created", resp.invoice.bindle.id);
+        }
+        SubCommand::SignInvoice(sign_opts) => {
+            // Role
+            let role = if let Some(r) = sign_opts.role {
+                role_from_name(r)?
+            } else {
+                SignatureRole::Creator
+            };
+            // Keyfile
+            let keyfile = sign_opts.secret_file.unwrap_or_else(|| {
+                default_config_dir()
+                    .unwrap_or_else(|| PathBuf::from("."))
+                    .join("secret_keys.toml")
+            });
+            // Signing key
+            let (key, label) = first_matching_key(keyfile, &role).await?;
+            println!("Signing {} with role {:?}", sign_opts.invoice, role);
+
+            let h = tokio::fs::read(sign_opts.invoice).await?;
+
+            let mut inv: Invoice = toml::from_slice(&h)?; //bindle::client::load::toml(sign_opts.invoice).await?;
+            inv.sign(label, role, key)?;
+
+            // Temporarily, we write to this special file. We need to figure out what we actually
+            // want to do.
+            let outfile = format!("./invoice-{}.toml", inv.canonical_name());
+            println!("Writing signed invoice to {}", outfile);
+            tokio::fs::write(outfile, toml::to_string(&inv)?).await?;
         }
         SubCommand::PushFile(push_opts) => {
             let label =
@@ -313,4 +342,31 @@ fn map_storage_error(e: ProviderError) -> ClientError {
 
 fn default_config_dir() -> Option<PathBuf> {
     dirs::config_dir().map(|v| v.join("bindle"))
+}
+
+fn role_from_name(name: String) -> Result<SignatureRole> {
+    match name.as_str() {
+        "c" | "creator" => Ok(SignatureRole::Creator),
+        "h" | "host" => Ok(SignatureRole::Host),
+        "a" | "approver" => Ok(SignatureRole::Approver),
+        "p" | "proxy" => Ok(SignatureRole::Proxy),
+        _ => Err(ClientError::Other("Unknown role".to_owned())),
+    }
+}
+
+async fn first_matching_key(fpath: PathBuf, role: &SignatureRole) -> Result<(Keypair, String)> {
+    let keys = SecretKeyFile::load_file(fpath.clone()).await.map_err(|e| {
+        ClientError::Other(format!(
+            "Error loading file {}: {}",
+            fpath.display(),
+            e.to_string()
+        ))
+    })?;
+    for key in keys.key {
+        if key.roles.contains(role) {
+            let pair = key.key().map_err(|e| ClientError::Other(e.to_string()))?;
+            return Ok((pair, key.label));
+        }
+    }
+    Err(ClientError::Other("No satisfactory key found".to_owned()))
 }

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -71,6 +71,11 @@ pub enum SubCommand {
         about = "creates a new signing key and places it in the local secret keys. If no secret file is provided, this will store in the default config directory for Bindle. The LABEL is typically a name and email address, of the form 'name <email>'."
     )]
     CreateKey(CreateKey),
+    #[clap(
+        name="sign-invoice",
+        about = "sign an invoice with the first creator key in your private keys"
+    )]
+    SignInvoice(SignInvoice),
 }
 
 #[derive(Clap)]
@@ -244,6 +249,28 @@ pub struct CreateKey {
         about = "the path to the file where secrets should be stored. If it does not exist, it will be created. If it does exist, the key will be appended."
     )]
     pub secret_file: Option<PathBuf>,
+}
+
+#[derive(Clap)]
+pub struct SignInvoice {
+    #[clap(
+        index = 1,
+        value_name = "INVOICE",
+        about = "the path to the invoice to sign"
+    )]
+    pub invoice: String,
+    #[clap(
+        short = 'f',
+        long = "secrets-file",
+        about = "the path to the file where secret keys are stored. Use 'create-key' to create a new key"
+    )]
+    pub secret_file: Option<PathBuf>,
+    #[clap(
+        short = 'r',
+        long = "role",
+        about = "the role to sign with. Values are: c[reator], a[pprover], h[ost], p[roxy]. If no role is specified, 'creator' is used"
+    )]
+    pub role: Option<String>,
 }
 
 #[derive(Clap)]

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -72,8 +72,8 @@ pub enum SubCommand {
     )]
     CreateKey(CreateKey),
     #[clap(
-        name="sign-invoice",
-        about = "sign an invoice with the first creator key in your private keys"
+        name = "sign-invoice",
+        about = "sign an invoice with one of your secret keys"
     )]
     SignInvoice(SignInvoice),
 }
@@ -271,6 +271,12 @@ pub struct SignInvoice {
         about = "the role to sign with. Values are: c[reator], a[pprover], h[ost], p[roxy]. If no role is specified, 'creator' is used"
     )]
     pub role: Option<String>,
+    #[clap(
+        short = 'o',
+        long = "out",
+        about = "the location to write the modified invoice. By default, it will write to invoice-HASH.toml, where HASH is computed on name and version"
+    )]
+    pub destination: Option<String>,
 }
 
 #[derive(Clap)]

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -55,6 +55,9 @@ pub enum ClientError {
     #[error("User has invalid credentials or is not authorized to access the requested resource")]
     Unauthorized,
 
+    #[error("Signature error: {0:?}")]
+    SignatureError(#[from] crate::invoice::signature::SignatureError),
+
     /// A catch-all for uncategorized errors. Contains an error message describing the underlying
     /// issue
     #[error("{0}")]

--- a/src/invoice/signature.rs
+++ b/src/invoice/signature.rs
@@ -52,6 +52,8 @@ pub enum SignatureError {
     UnknownSigningKey(String),
     #[error("none of the signatures are made with a known key")]
     NoKnownKey,
+    #[error("cannot sign the data again with a key that has already signed the data")]
+    DuplicateSignature,
 }
 
 /// The role of a signer in a signature block.
@@ -183,6 +185,8 @@ impl SecretKeyEntry {
         })?;
         let keypair = Keypair::from_bytes(&rawbytes).map_err(|e| {
             log::error!("Error loading key: {}", e);
+            // Don't leak information about the key, because this could be sent to
+            // a remote. A generic error is all the user should see.
             SignatureError::CorruptKey("Could not load keypair".to_owned())
         })?;
         Ok(keypair)


### PR DESCRIPTION
This is the third step toward implementing signing and verification. It uses a key created with `create-key` and signs an invoice.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>