### PR TITLE
update docs, add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+SERVER_FEATURES ?= "--all-features"
+SERVER_BIN := "bindle-server"
+CLIENT_FEATURES ?= "--features=cli"
+CLIENT_BIN := "bindle"
+BINDLE_LOG_LEVEL ?= "debug"
+
+.PHONY: test
+test:
+	cargo test
+
+.PHONY: serve
+serve:
+	RUST_LOG=debug,bindle::*=${BINDLE_LOG_LEVEL}\ 
+	cargo run ${SERVER_FEATURES} --bin ${SERVER_BIN}
+
+# Sort of a wacky hack if you want to do `$(make client) --help`
+.PHONY: client
+client:
+	@echo cargo run ${CLIENT_FEATURES} --bin ${CLIENT_BIN} -- 
+
+.PHONY: build
+build: build-server
+build: build-client
+
+.PHONY: build-server
+build-server:
+	cargo build ${SERVER_FEATURES} --bin ${SERVER_BIN}
+
+.PHONY: build-client
+build-client:
+	cargo build ${CLIENT_FEATURES} --bin ${CLIENT_BIN}
+	

--- a/README.md
+++ b/README.md
@@ -76,9 +76,55 @@ Enough with talk, let's get down to the business of using Bindle.
 
 ## Using Bindle
 
-This is a Rust project. The simplest way to get started is to clone this repository and then run `cargo run --bin bindle-serve`. That will start up a Bindle server.
+To build Bindle, you can use `make` or `cargo`:
 
-In a separate terminal, you can run `cargo run --bin bindle` to execute the client, but you may find it easier to `cargo build` and then use the `bindle` client as a compiled binary.
+```console
+$ # Recommended
+$ make build
+$ # The above is approximately equivalent to:
+$ cargo build --feature=cli --bin bindle
+$ cargo build --all-features --bin bindle-server
+```
+
+The binaries will be built in `target/debug/bindle` and `target/debug/bindle-server`.
+For both client and server, the `--help` flag will print out documentation.
+
+### Starting the Server
+
+To start the compiled server, simply run `target/debug/bindle-server`. If you would like
+to see the available options, use the `--help` command.
+
+If you would like to run the server with `cargo run` (useful when debugging), use `make serve`.
+
+#### Supplying a Configuration File
+
+The Bindle server looks for a configuration file in `$XDG_DATA/bindle/server.toml`.
+If it finds one, it loads configuration from there.
+You can override this location with the `--config-path path/to/some.toml` flag.
+
+```toml
+address = "127.0.0.1:8080"
+bindle-directory = "/var/run/bindle"
+cert-path = "/etc/ssl/bindle/certificate.pem"
+key-path = "/etc/ssl/bindle/key.pem"
+```
+
+### Running the Client
+
+If you compiled, the client is in `target/debug/bindle`. You can also run from source with
+`cargo run --features=cli --bin=bindle` or `$(make client)` (e.g. `$(make client) --help`).
+
+You will either need to supply the `--server` parameter on the command line or set the `BINDLE_SERVER_URL`.
+
+```console
+$ export BINDLE_SERVER_URL="http://localhost:8080/v1"
+$ # Running from build
+$ target/debug/bindle --help
+$ # Running from Cargo
+$ cargo run --bin bindle --features=cli -- --help
+$ # Running from make
+$ $(make client) --help
+```
 
 For more, see [the docs](docs/README.md).
 

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -15,7 +15,7 @@ pub struct Opts {
         short = 's',
         long = "server",
         env = "BINDLE_SERVER_URL",
-        about = "The address of the bindle server"
+        about = "The address of the bindle server. For the default local server, this should be http://localhost:8080/v1"
     )]
     pub server_url: String,
     #[clap(
@@ -113,7 +113,11 @@ pub struct Push {
 
 #[derive(Clap)]
 pub struct Get {
-    #[clap(index = 1, value_name = "BINDLE")]
+    #[clap(
+        index = 1,
+        value_name = "BINDLE",
+        about = "The name of the bindle, e.g. example.com/mybindle/1.2.3"
+    )]
     pub bindle_id: String,
     #[clap(
         short = 'y',
@@ -131,7 +135,11 @@ pub struct Get {
 
 #[derive(Clap)]
 pub struct Yank {
-    #[clap(index = 1, value_name = "BINDLE")]
+    #[clap(
+        index = 1,
+        value_name = "BINDLE",
+        about = "The name of the bindle, e.g. example.com/mybindle/1.2.3"
+    )]
     pub bindle_id: String,
 }
 
@@ -193,9 +201,17 @@ impl From<Search> for bindle::QueryOptions {
 
 #[derive(Clap)]
 pub struct GetParcel {
-    #[clap(index = 1, value_name = "BINDLE_ID")]
+    #[clap(
+        index = 1,
+        value_name = "BINDLE_ID",
+        about = "The name of the bindle, e.g. example.com/mybindle/1.2.3"
+    )]
     pub bindle_id: bindle::Id,
-    #[clap(index = 2, value_name = "PARCEL_SHA")]
+    #[clap(
+        index = 2,
+        value_name = "PARCEL_SHA",
+        about = "The SHA256 of the parcel"
+    )]
     pub sha: String,
     #[clap(
         short = 'o',
@@ -208,7 +224,11 @@ pub struct GetParcel {
 
 #[derive(Clap)]
 pub struct GetInvoice {
-    #[clap(index = 1, value_name = "BINDLE")]
+    #[clap(
+        index = 1,
+        value_name = "BINDLE",
+        about = "The name of the bindle, e.g. example.com/mybindle/1.2.3"
+    )]
     pub bindle_id: String,
     #[clap(
         short = 'o',
@@ -227,7 +247,11 @@ pub struct GetInvoice {
 
 #[derive(Clap)]
 pub struct GenerateLabel {
-    #[clap(index = 1, value_name = "FILE")]
+    #[clap(
+        index = 1,
+        value_name = "FILE",
+        about = "The path to a file. This will generate a label for the file at that path"
+    )]
     pub path: PathBuf,
     #[clap(
         short = 'n',
@@ -302,7 +326,11 @@ pub struct PushInvoice {
 pub struct PushFile {
     #[clap(index = 1, value_name = "BINDLE_ID")]
     pub bindle_id: bindle::Id,
-    #[clap(index = 2, value_name = "FILE")]
+    #[clap(
+        index = 2,
+        value_name = "FILE",
+        about = "The path to the file that should be pushed as a parcel"
+    )]
     pub path: PathBuf,
     #[clap(
         short = 'n',

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,23 @@
 
 ## Installing Bindle
 
+### From Source
+
+Prerequisites:
+
+- A recent version of Rust and Cargo
+
+Clone the repository at https://github.com/deislabs/bindle, and then use `make` to build
+the binaries:
+
+```console
+$ git clone https://github.com/deislabs/bindle.git
+$ cd bindle
+$ make build
+```
+
+You will now have binaries built in `target/debug/bindle` and `target/debug/bindle-server`.
+
 ### From the Binary Releases
 
 Every release of Bindle provides compiled releases for a variety of operating systems. These
@@ -42,6 +59,12 @@ Here are links to the common builds:
 ## Using Bindle
 
 The `bindle` program is the client. The `bindle-server` program is the HTTP server.
+
+Before using the `bindle` client, set the `BINDLE_SERVER_URL` environment variable:
+
+```console
+$ export BINDLE_SERVER_URL="http://localhost:8080/v1/" 
+```
 
 To bootstrap a new bindle instance:
 


### PR DESCRIPTION
This updates the docs and adds a `Makefile` that hides away the growing complexity of our cargo commands.

Closes #125 

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>