### PR TITLE
Verify creator on invoice upload

### DIFF
--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -345,8 +345,7 @@ async fn load_keyring(keyring: Option<PathBuf>) -> anyhow::Result<KeyRing> {
     // This takes an Option<PathBuf> because we want to wrap all of the flag handling in this
     // function, including setting the default if the kyering is None.
     let dir = keyring
-        .clone()
-        .unwrap_or_else(|| default_config_dir().unwrap_or_else(|| PathBuf::from(".bindle")))
+        .unwrap_or_else(|| default_config_dir())
         .join("keyring.toml");
     let kr = bindle::client::load::toml(dir).await?;
     Ok(kr)
@@ -360,8 +359,10 @@ fn map_storage_error(e: ProviderError) -> ClientError {
     }
 }
 
-fn default_config_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|v| v.join("bindle"))
+fn default_config_dir() -> PathBuf {
+    dirs::config_dir()
+        .map(|v| v.join("bindle/"))
+        .unwrap_or_else(|| "./bindle".into())
 }
 
 /// Get the config dir, ensuring that it exists.
@@ -374,7 +375,7 @@ fn default_config_dir() -> Option<PathBuf> {
 ///
 /// This will return an error
 async fn ensure_config_dir() -> Result<PathBuf> {
-    let dir = default_config_dir().unwrap_or_else(|| PathBuf::from("./bindle"));
+    let dir = default_config_dir();
     tokio::fs::create_dir_all(dir.clone()).await?;
     Ok(dir)
 }

--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -2,7 +2,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use bindle::client::{Client, ClientError, Result};
-use bindle::invoice::signature::{KeyRing, SecretKeyEntry, SecretKeyFile, SignatureRole};
+use bindle::invoice::signature::{
+    KeyRing, SecretKeyEntry, SecretKeyFile, SecretKeyStorage, SignatureRole,
+};
 use bindle::invoice::Invoice;
 use bindle::provider::ProviderError;
 use bindle::standalone::{StandaloneRead, StandaloneWrite};

--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -112,7 +112,7 @@ async fn main() -> std::result::Result<(), ClientError> {
 
             // Load the invoice and sign it.
             let mut inv: Invoice = bindle::client::load::toml(sign_opts.invoice.as_str()).await?;
-            inv.sign(key.label.clone(), role.clone(), &key)?;
+            inv.sign(role.clone(), &key)?;
 
             // Write the signed invoice to a file.
             let outfile = sign_opts

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -25,6 +25,14 @@ pub struct Opts {
         about = "The directory where bindles are stored/cached, defaults to $XDG_CACHE_HOME"
     )]
     pub bindle_dir: Option<PathBuf>,
+
+    #[clap(
+        short = 'r',
+        long = "keyring",
+        about = "The path to the keyring file. Defaults to $XDG_CONFIG/bindle/keyring.toml"
+    )]
+    pub keyring: Option<PathBuf>,
+
     #[clap(subcommand)]
     pub subcmd: SubCommand,
 }

--- a/bin/server.rs
+++ b/bin/server.rs
@@ -157,7 +157,7 @@ async fn main() -> anyhow::Result<()> {
             keyring_file.display()
         ))?,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            println!("No keyring.toml found.");
+            println!("No keyring.toml found. Using default keyring.");
             KeyRing::default()
         }
         Err(e) => anyhow::bail!("failed to read file {}: {}", keyring_file.display(), e),

--- a/bin/server.rs
+++ b/bin/server.rs
@@ -142,11 +142,7 @@ async fn main() -> anyhow::Result<()> {
                 .get("keyring")
                 .map(|v| v.as_str().unwrap().parse().unwrap())
         })
-        .unwrap_or(PathBuf::from(
-            default_config_dir()
-                .unwrap_or_else(|| PathBuf::from("./bindle"))
-                .join("keyring.toml"),
-        ));
+        .unwrap_or(PathBuf::from(default_config_dir().join("keyring.toml")));
 
     // We might want to do something different in the future. But what we do here is
     // load the file if we can find it. If the file just doesn't exist, we print a
@@ -236,12 +232,14 @@ async fn main() -> anyhow::Result<()> {
 fn default_config_file() -> Option<PathBuf> {
     dirs::config_dir().map(|v| v.join("bindle/server.toml"))
 }
-fn default_config_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|v| v.join("bindle/"))
+fn default_config_dir() -> PathBuf {
+    dirs::config_dir()
+        .map(|v| v.join("bindle/"))
+        .unwrap_or_else(|| "./bindle".into())
 }
 
 async fn ensure_config_dir() -> anyhow::Result<PathBuf> {
-    let dir = default_config_dir().unwrap_or_else(|| PathBuf::from("./bindle"));
+    let dir = default_config_dir();
     tokio::fs::create_dir_all(dir.clone()).await?;
     Ok(dir)
 }

--- a/bin/server.rs
+++ b/bin/server.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use clap::Clap;
+use tracing::warn;
 
 use bindle::{
     invoice::signature::{KeyRing, SignatureRole},
@@ -94,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let config: toml::Value = load_toml(config_file_path).await.unwrap_or_else(|_| {
-        println!("No server.toml file loaded");
+        warn!("No server.toml file loaded");
         toml::Value::Table(toml::value::Table::new())
     });
 
@@ -157,7 +158,7 @@ async fn main() -> anyhow::Result<()> {
             keyring_file.display()
         ))?,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            println!("No keyring.toml found. Using default keyring.");
+            warn!("No keyring.toml found. Using default keyring.");
             KeyRing::default()
         }
         Err(e) => anyhow::bail!("failed to read file {}: {}", keyring_file.display(), e),
@@ -255,7 +256,7 @@ async fn ensure_signing_keys() -> anyhow::Result<PathBuf> {
         // If the file is not found, then drop through and create a default instance
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             let mut default_keyfile = SecretKeyFile::default();
-            println!(
+            warn!(
                 "Creating a default host signing key and storing it in {}",
                 signing_keyfile.display()
             );

--- a/docs/signing-spec.md
+++ b/docs/signing-spec.md
@@ -334,7 +334,7 @@ The result is that every signature is partially tested, at least one must be ful
 
 (Bindle currently implements this strategy, but in the future, strategy will be configurable)
 
-## Strategy 5: Complete Verification
+## Strategy 5: Exhaustive Verification
 
 In this strategy, _every signature on the invoice_ must be verified.
 

--- a/src/cache/dumb.rs
+++ b/src/cache/dumb.rs
@@ -61,12 +61,13 @@ where
         match possible_entry {
             Some(inv) => Ok(inv),
             None => {
+                let parsed_id = parsed_id.clone();
                 async {
                     debug!(
                         "Cache miss for invoice {}, attempting to fetch from server",
                         parsed_id
                     );
-                    let inv = self.remote.get_yanked_invoice(parsed_id).await?;
+                    let inv = self.remote.get_yanked_invoice(parsed_id.clone()).await?;
 
                     // TODO: In this case, we should be signing with a proxy key. The reason
                     // is that we are receiving from a remote (self.remote) and then storing

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -369,8 +369,6 @@ mod test {
         let invoice: crate::Invoice = toml::from_str(invoice).expect("a nice clean parse");
 
         // Parse the key from the above example, and put it into the keyring.
-        let rawkey =
-            base64::decode("jTtZIzQCfZh8xy6st40xxLwxVw++cf0C0cMH3nJBF+c=").expect("key decoded");
         let pubkey = KeyEntry {
             key: "jTtZIzQCfZh8xy6st40xxLwxVw++cf0C0cMH3nJBF+c=".to_owned(),
             label: "Test Key".to_owned(),
@@ -422,10 +420,6 @@ mod test {
         "#;
 
         let invoice: crate::Invoice = toml::from_str(invoice).expect("a nice clean parse");
-
-        // This is a valid key. We just need something to have on the keyring.
-        //let rawkey = base64::decode("jTtZIzQCfZh8xy6st40xxLwxVw++cf0C0cMH3nJBF+c=").expect("key decoded");
-        //let pubkey = PublicKey::from_bytes(rawkey.as_slice()).expect("key converted");
 
         // Set up a keyring
         let keyring = KeyRing::new(vec![KeyEntry {

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -424,8 +424,7 @@ mod test {
         let invoice: crate::Invoice = toml::from_str(invoice).expect("a nice clean parse");
 
         // This is a valid key. We just need something to have on the keyring.
-        let rawkey =
-            base64::decode("jTtZIzQCfZh8xy6st40xxLwxVw++cf0C0cMH3nJBF+c=").expect("key decoded");
+        //let rawkey = base64::decode("jTtZIzQCfZh8xy6st40xxLwxVw++cf0C0cMH3nJBF+c=").expect("key decoded");
         //let pubkey = PublicKey::from_bytes(rawkey.as_slice()).expect("key converted");
 
         // Set up a keyring

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -322,11 +322,9 @@ mod test {
         assert_eq!(2, invoice.signature.as_ref().unwrap().len());
 
         // With the keyring, the signature should work
-        println!("==== IN");
         VerificationStrategy::CreativeIntegrity
             .verify(&invoice, &keyring)
             .expect("with keys on the keyring, this should pass");
-        println!("==== OUT");
 
         // If we switch the keys in the keyring, this should fail because the Creator
         // key is not on the ring.

--- a/src/invoice/signature.rs
+++ b/src/invoice/signature.rs
@@ -3,6 +3,7 @@
 pub use ed25519_dalek::{Keypair, PublicKey, Signature as EdSignature, Signer};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::error;
 
 use std::convert::{TryFrom, TryInto};
 use std::fmt::{Display, Formatter, Result as FmtResult};
@@ -196,7 +197,7 @@ impl KeyEntry {
             SignatureError::CorruptKey("Base64 decoding of the public key failed".to_owned())
         })?;
         let pk = PublicKey::from_bytes(rawbytes.as_slice()).map_err(|e| {
-            log::error!("Error loading public key: {}", e);
+            error!(%e, "Error loading public key");
             // Don't leak information about the key, because this could be sent to
             // a remote. A generic error is all the user should see.
             SignatureError::CorruptKey("Could not load keypair".to_owned())

--- a/src/invoice/signature.rs
+++ b/src/invoice/signature.rs
@@ -235,6 +235,7 @@ impl SecretKeyFile {
 pub struct SecretKeyFileLoader {
     path: PathBuf,
 }
+
 impl SecretKeyFileLoader {
     pub async fn load_file(&self) -> anyhow::Result<SecretKeyFile> {
         let s = tokio::fs::read_to_string(self.path.clone()).await?;
@@ -249,12 +250,6 @@ impl SecretKeyFileLoader {
         Ok(())
     }
 }
-// impl TryInto<SecretKeyFile> for SecretKeyFileLoader {
-//     type Error = anyhow::Error;
-//     fn try_into(self) -> Result<SecretKeyFile, Self::Error> {
-//         self.load_file()
-//     }
-// }
 
 #[cfg(test)]
 mod test {

--- a/src/invoice/signature.rs
+++ b/src/invoice/signature.rs
@@ -177,7 +177,7 @@ impl SecretKeyEntry {
         }
     }
 
-    pub fn key(&self) -> Result<Keypair, SignatureError> {
+    pub(crate) fn key(&self) -> Result<Keypair, SignatureError> {
         let rawbytes = base64::decode(&self.keypair).map_err(|_e| {
             // We swallow the source error because it could disclose information about
             // the secret key.
@@ -192,6 +192,10 @@ impl SecretKeyEntry {
         Ok(keypair)
     }
 }
+
+// pub trait KeyLoader {
+//     fn load(&self) -> anyhow::Result<SecretKeyFile>;
+// }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -221,6 +225,10 @@ impl SecretKeyFile {
         let out = toml::to_vec(self)?;
         tokio::fs::write(dest, out).await?;
         Ok(())
+    }
+
+    pub fn get_first_matching(&self, role: SignatureRole) -> Option<SecretKeyEntry> {
+        self.key.iter().find(|key| k.roles.contains(role)).clone()
     }
 }
 

--- a/src/invoice/verification.rs
+++ b/src/invoice/verification.rs
@@ -1,0 +1,365 @@
+use super::{Invoice, Signature, SignatureError, SignatureRole};
+use ed25519_dalek::{PublicKey, Signature as EdSignature};
+
+use std::convert::TryInto;
+
+/// This enumerates the verifications strategies described in the signing spec.
+pub enum VerificationStrategy {
+    /// CreativeIntegrity verifies that (a) the key that signs as Creator is a known key,
+    /// and that the signature is valid.
+    CreativeIntegrity,
+    /// AuthoritativeIntegrity verifies that at least one of the Creator or Approver keys
+    /// is known and the signature is valid.
+    AuthoritativeIntegrity,
+    /// Verify that the Creator key is known and that all signatures are valid.
+    ///
+    /// This is subject to a DOS attack if a signer can generate intentionally bad signatures.
+    GreedyVerification,
+    /// Verify that every key on the invoice is known, and that every signature is valid.
+    ExhaustiveVerification,
+    /// Verifies that all signatures of the given roles are valid and signed by know keys.
+    ///
+    /// If the bool is true, unknown signers will also be valdidated.
+    /// Be aware that doing so may make the validation subject to a special for of
+    /// DOS attack in which someone can generate a known-bad signature.
+    MultipleAttestation(Vec<SignatureRole>, bool),
+}
+
+impl Default for VerificationStrategy {
+    fn default() -> Self {
+        VerificationStrategy::GreedyVerification
+    }
+}
+
+/// A strategy for verifying an invoice.
+impl VerificationStrategy {
+    fn verify_signature(&self, sig: &Signature, cleartext: &[u8]) -> Result<(), SignatureError> {
+        let pk = base64::decode(sig.key.as_bytes())
+            .map_err(|_| SignatureError::CorruptKey(sig.key.clone()))?;
+        let sig_block = base64::decode(sig.signature.as_bytes())
+            .map_err(|_| SignatureError::CorruptSignature(sig.key.clone()))?;
+
+        let pubkey =
+            PublicKey::from_bytes(&pk).map_err(|_| SignatureError::CorruptKey(sig.key.clone()))?;
+        let ed_sig = EdSignature::new(
+            sig_block
+                .as_slice()
+                .try_into()
+                .map_err(|_| SignatureError::CorruptSignature(sig.key.clone()))?,
+        );
+        pubkey
+            .verify_strict(cleartext, &ed_sig)
+            .map_err(|_| SignatureError::Unverified(sig.key.clone()))
+    }
+    pub fn verify(&self, inv: &Invoice, keyring: &Vec<PublicKey>) -> Result<(), SignatureError> {
+        let (roles, all_valid, all_verified, all_roles) = match self {
+            VerificationStrategy::GreedyVerification => {
+                (vec![SignatureRole::Creator], true, true, true)
+            }
+            VerificationStrategy::CreativeIntegrity => {
+                (vec![SignatureRole::Creator], false, true, true)
+            }
+            VerificationStrategy::AuthoritativeIntegrity => (
+                vec![SignatureRole::Creator, SignatureRole::Approver],
+                false,
+                false,
+                false,
+            ),
+            VerificationStrategy::ExhaustiveVerification => (
+                vec![
+                    SignatureRole::Creator,
+                    SignatureRole::Approver,
+                    SignatureRole::Host,
+                    SignatureRole::Proxy,
+                ],
+                true,
+                true,
+                false,
+            ),
+            VerificationStrategy::MultipleAttestation(a, b) => (a.clone(), b.clone(), true, true),
+        };
+
+        // Either the Creator or an Approver must be in the keyring
+        match inv.signature.as_ref() {
+            None => Ok(()),
+            Some(signatures) => {
+                let mut known_key = false;
+                let mut filled_roles: Vec<SignatureRole> = vec![];
+                for s in signatures {
+                    log::debug!("Checking signature for {}", s.by.clone());
+                    let target_role = roles.contains(&s.role);
+
+                    // If we're not validating all, and this role isn't one we're interested in,
+                    // skip it.
+                    if !all_valid && !target_role {
+                        log::debug!("Not a target role, and not running all_valid");
+                        continue;
+                    }
+
+                    let role = s.role.clone();
+                    let cleartext = inv.cleartext(s.by.clone(), role.clone());
+
+                    // Verify the signature
+                    // TODO: This would allow a trivial DOS attack in which an attacker
+                    // would only need to attach a known-bad signature, and that would
+                    // prevent the module from ever being usable. This is marginally
+                    // better if we only verify signatures on known keys.
+                    self.verify_signature(&s, cleartext.as_bytes())?;
+
+                    if !target_role && !all_verified {
+                        log::debug!("Not a target role, not checking for verification");
+                        continue;
+                    } else if all_roles {
+                        filled_roles.push(role);
+                    }
+                    // See if the public key is known to us
+                    let pubkey = base64::decode(s.key.clone())
+                        .map_err(|_| SignatureError::CorruptKey(s.key.to_string()))?;
+                    let pko = PublicKey::from_bytes(pubkey.as_slice())
+                        .map_err(|_| SignatureError::CorruptKey(s.key.to_string()))?;
+
+                    // If the keyring contains PKO, then we are successful for this round.
+                    if keyring.contains(&pko) {
+                        log::debug!("Found key {}", s.by.clone());
+                        known_key = true;
+                    } else if all_verified {
+                        // If the keyring does not contain pko AND every key must be known,
+                        // then we bail on error early.
+                        return Err(SignatureError::Unverified(
+                            "strategy requires that all signatures for role(s) must be verified"
+                                .to_owned(),
+                        ));
+                    }
+                }
+                if !known_key {
+                    // If we get here, then the none of the signatures were created with
+                    // a key from the keyring. This means the package is untrusted.
+                    return Err(SignatureError::NoKnownKey);
+                }
+                // If we are supposed to make sure that all are valid, then we need to make sure
+                // that at least one of each requested role is present.
+                if all_roles {
+                    for should_role in roles {
+                        if !filled_roles.contains(&should_role) {
+                            return Err(SignatureError::Unverified(format!(
+                                "No signature found for role {:?}",
+                                should_role,
+                            )));
+                        }
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::invoice::*;
+
+    #[test]
+    fn test_verification_strategies() {
+        let invoice = r#"
+        bindleVersion = "1.0.0"
+
+        [bindle]
+        name = "aricebo"
+        version = "1.2.3"
+
+        [[parcel]]
+        [parcel.label]
+        sha256 = "aaabbbcccdddeeefff"
+        name = "telescope.gif"
+        mediaType = "image/gif"
+        size = 123_456
+        
+        [[parcel]]
+        [parcel.label]
+        sha256 = "111aaabbbcccdddeee"
+        name = "telescope.txt"
+        mediaType = "text/plain"
+        size = 123_456
+        "#;
+        let invoice: crate::Invoice = toml::from_str(invoice).expect("a nice clean parse");
+
+        let key_creator =
+            SecretKeyEntry::new("Test Creator".to_owned(), vec![SignatureRole::Creator]);
+        let key_approver =
+            SecretKeyEntry::new("Test Approver".to_owned(), vec![SignatureRole::Approver]);
+        let key_host = SecretKeyEntry::new("Test Host".to_owned(), vec![SignatureRole::Host]);
+        let key_proxy = SecretKeyEntry::new("Test Proxy".to_owned(), vec![SignatureRole::Proxy]);
+        let keyring = vec![
+            key_approver.key().expect("fetch key").public,
+            key_host.key().expect("fetch key").public,
+            key_creator.key().expect("fetch key").public,
+            key_proxy.key().expect("fetch key").public,
+        ];
+
+        // Only signed by host
+        {
+            let mut inv = invoice.clone();
+            inv.sign(SignatureRole::Host, &key_host)
+                .expect("signed as host");
+            // This should fail
+            VerificationStrategy::CreativeIntegrity
+                .verify(&inv, &keyring)
+                .expect_err("inv should not pass: Requires creator");
+            VerificationStrategy::AuthoritativeIntegrity
+                .verify(&inv, &keyring)
+                .expect_err("inv should not pass: Requires creator or approver");
+            VerificationStrategy::GreedyVerification
+                .verify(&inv, &keyring)
+                .expect_err("inv should not pass: Requires creator and all valid");
+            VerificationStrategy::MultipleAttestation(vec![SignatureRole::Host], true)
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Only requires host");
+            VerificationStrategy::MultipleAttestation(
+                vec![SignatureRole::Host, SignatureRole::Proxy],
+                true,
+            )
+            .verify(&inv, &keyring)
+            .expect_err("inv should not pass: Requires proxy");
+
+            VerificationStrategy::ExhaustiveVerification
+                .verify(&inv, &keyring)
+                .expect("inv should not pass: Requires that all signatures must be verified");
+        }
+        // Signed by creator and host
+        {
+            let mut inv = invoice.clone();
+            inv.sign(SignatureRole::Host, &key_host)
+                .expect("signed as host");
+            inv.sign(SignatureRole::Creator, &key_creator)
+                .expect("signed as creator");
+            // This should fail
+            VerificationStrategy::CreativeIntegrity
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Signed by creator");
+            VerificationStrategy::AuthoritativeIntegrity
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Signed by creator");
+            VerificationStrategy::GreedyVerification
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Requires creator and all valid");
+            VerificationStrategy::MultipleAttestation(vec![SignatureRole::Host], true)
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Only requires host");
+            VerificationStrategy::MultipleAttestation(
+                vec![SignatureRole::Host, SignatureRole::Proxy],
+                true,
+            )
+            .verify(&inv, &keyring)
+            .expect_err("inv should not pass: Requires proxy");
+
+            VerificationStrategy::ExhaustiveVerification
+                .verify(&inv, &keyring)
+                .expect("inv should not pass: Requires that all signatures must be verified");
+        }
+        // Signed by approver and host
+        {
+            let mut inv = invoice.clone();
+            inv.sign(SignatureRole::Host, &key_host)
+                .expect("signed as host");
+            inv.sign(SignatureRole::Approver, &key_approver)
+                .expect("signed as approver");
+            // This should fail
+            VerificationStrategy::CreativeIntegrity
+                .verify(&inv, &keyring)
+                .expect_err("inv should not pass: not signed by creator");
+            VerificationStrategy::AuthoritativeIntegrity
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Signed by approver");
+            VerificationStrategy::GreedyVerification
+                .verify(&inv, &keyring)
+                .expect_err("inv should not pass: Requires creator and all valid");
+            VerificationStrategy::MultipleAttestation(vec![SignatureRole::Host], true)
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Only requires host");
+            VerificationStrategy::MultipleAttestation(
+                vec![SignatureRole::Host, SignatureRole::Proxy],
+                true,
+            )
+            .verify(&inv, &keyring)
+            .expect_err("inv should not pass: Requires proxy");
+
+            VerificationStrategy::ExhaustiveVerification
+                .verify(&inv, &keyring)
+                .expect("inv should not pass: Requires that all signatures must be verified");
+        }
+        // Signed by creator, proxy, and host
+        {
+            let mut inv = invoice.clone();
+            inv.sign(SignatureRole::Host, &key_host)
+                .expect("signed as host");
+            inv.sign(SignatureRole::Creator, &key_creator)
+                .expect("signed as creator");
+            inv.sign(SignatureRole::Proxy, &key_proxy)
+                .expect("signed as proxy");
+            // This should fail
+            VerificationStrategy::CreativeIntegrity
+                .verify(&inv, &keyring)
+                .expect("inv should pass: signed by creator");
+            VerificationStrategy::AuthoritativeIntegrity
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Signed by creator");
+            VerificationStrategy::GreedyVerification
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Requires creator and all valid");
+            VerificationStrategy::MultipleAttestation(vec![SignatureRole::Host], true)
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Only requires host");
+            VerificationStrategy::MultipleAttestation(
+                vec![SignatureRole::Host, SignatureRole::Proxy],
+                true,
+            )
+            .verify(&inv, &keyring)
+            .expect("inv should pass: Requires proxy");
+
+            VerificationStrategy::ExhaustiveVerification
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Requires that all signatures must be verified");
+        }
+        println!("Signed by creator, host, and unknown key");
+        {
+            let mut inv = invoice.clone();
+            inv.sign(SignatureRole::Host, &key_host)
+                .expect("signed as host");
+            inv.sign(SignatureRole::Creator, &key_creator)
+                .expect("signed as creator");
+
+            // Mock an unknown key and don't add it to keyring
+            let key_anon =
+                SecretKeyEntry::new("Unknown key".to_owned(), vec![SignatureRole::Approver]);
+            inv.sign(SignatureRole::Approver, &key_anon)
+                .expect("signed with unknown key");
+
+            // This should fail
+            VerificationStrategy::CreativeIntegrity
+                .verify(&inv, &keyring)
+                .expect("inv should pass: signed by creator");
+            VerificationStrategy::AuthoritativeIntegrity
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Signed by creator");
+            VerificationStrategy::GreedyVerification
+                .verify(&inv, &keyring)
+                .expect_err(
+                    "inv should not pass: Requires creator and all known, anon is not known",
+                );
+            VerificationStrategy::MultipleAttestation(vec![SignatureRole::Host], false)
+                .verify(&inv, &keyring)
+                .expect("inv should pass: Only requires host");
+            VerificationStrategy::MultipleAttestation(
+                vec![SignatureRole::Host, SignatureRole::Approver],
+                true,
+            )
+            .verify(&inv, &keyring)
+            .expect_err("inv should not pass: Requires approver to be known");
+
+            VerificationStrategy::ExhaustiveVerification
+                .verify(&inv, &keyring)
+                .expect_err("inv should not pass: Requires that all signatures must be verified");
+        }
+    }
+}

--- a/src/invoice/verification.rs
+++ b/src/invoice/verification.rs
@@ -51,6 +51,23 @@ impl VerificationStrategy {
             .verify_strict(cleartext, &ed_sig)
             .map_err(|_| SignatureError::Unverified(sig.key.clone()))
     }
+    /// Verify that every signature on this invoice is correct.
+    ///
+    /// The verification strategy will determine how this verification is performed.
+    /// Depending on the selected strategy, the `[[signature]]` blocks will be evaluated
+    /// for the following:
+    ///
+    /// - Is the key in the keyring?
+    /// - Can the signature be verified?
+    ///
+    /// Note that the purpose of the keyring is to ensure that we know about the
+    /// entity that claims to have signed the invoice.
+    ///
+    /// If no signatures are on the invoice, this will succeed.
+    ///
+    /// A strategy will determine success or failure based on whether the signature is verified,
+    /// whether the keys are known, whether the requisite number/roles are satisfied, and
+    /// so on.
     pub fn verify(&self, inv: &Invoice, keyring: &Vec<PublicKey>) -> Result<(), SignatureError> {
         let (roles, all_valid, all_verified, all_roles) = match self {
             VerificationStrategy::GreedyVerification => {

--- a/src/invoice/verification.rs
+++ b/src/invoice/verification.rs
@@ -1,11 +1,12 @@
 use super::signature::KeyRing;
 use super::{Invoice, Signature, SignatureError, SignatureRole};
 use ed25519_dalek::{PublicKey, Signature as EdSignature};
-use log::debug;
+use tracing::debug;
 
 use std::convert::TryInto;
 
 /// This enumerates the verifications strategies described in the signing spec.
+#[derive(Debug)]
 pub enum VerificationStrategy {
     /// CreativeIntegrity verifies that (a) the key that signs as Creator is a known key,
     /// and that the signature is valid.
@@ -105,14 +106,13 @@ impl VerificationStrategy {
                 let mut known_key = false;
                 let mut filled_roles: Vec<SignatureRole> = vec![];
                 for s in signatures {
-                    log::debug!("Checking signature for {}", s.by.clone());
-                    debug!("Checking signature for {}", s.by.clone());
+                    debug!(by = %s.by, "Checking signature");
                     let target_role = roles.contains(&s.role);
 
                     // If we're not validating all, and this role isn't one we're interested in,
                     // skip it.
                     if !all_valid && !target_role {
-                        log::debug!("Not a target role, and not running all_valid");
+                        debug!("Not a target role, and not running all_valid");
                         continue;
                     }
 
@@ -128,7 +128,7 @@ impl VerificationStrategy {
                     debug!("Signature verified");
 
                     if !target_role && !all_verified {
-                        log::debug!("Not a target role, not checking for verification");
+                        debug!("Not a target role, not checking for verification");
                         continue;
                     } else if all_roles {
                         filled_roles.push(role);

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -72,17 +72,6 @@ pub trait Provider {
         Ok(())
     }
 
-    // TODO: This can probably be removed.
-    fn verify_invoice(
-        &self,
-        inv: &super::Invoice,
-        strategy: VerificationStrategy,
-        keys: &super::signature::KeyRing,
-    ) -> Result<()> {
-        strategy.verify(inv, keys)?;
-        Ok(())
-    }
-
     /// Load an invoice and return it
     ///
     /// This will return an invoice if the bindle exists and is not yanked. The default

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -29,11 +29,15 @@ use thiserror::Error;
 use tokio_stream::Stream;
 
 use crate::id::ParseError;
+use crate::invoice::{
+    signature::SecretKeyFileLoader, Invoice, SignatureRole, VerificationStrategy,
+};
 use crate::Id;
 
 /// A custom shorthand result type that always has an error type of [`ProviderError`](ProviderError)
 pub type Result<T> = core::result::Result<T, ProviderError>;
 
+/*
 pub trait Strategy {
     fn validate(&self, inv: &Invoice) -> Result<()>;
 }
@@ -50,6 +54,7 @@ impl BasicStrategy {
 pub trait KeyLoader {
     fn load(&self) -> Result<SecretKeyFile>;
 }
+*/
 
 /// The basic functionality required for a Bindle provider.
 ///
@@ -72,8 +77,8 @@ pub trait Provider {
         &self,
         inv: &super::Invoice,
         role: SignatureRole,
-        key: TryInto<SecretKeyFile>,
-        verification_strategy: VerificationStrategy,
+        keyloader: SecretKeyFileLoader,
+        verification_strategy: impl VerificationStrategy,
     ) -> Result<Vec<super::Label>>;
 
     /// Load an invoice and return it

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -72,13 +72,14 @@ pub trait Provider {
         Ok(())
     }
 
+    // TODO: This can probably be removed.
     fn verify_invoice(
         &self,
         inv: &super::Invoice,
         strategy: VerificationStrategy,
-        keys: Vec<super::signature::PublicKey>,
+        keys: &super::signature::KeyRing,
     ) -> Result<()> {
-        strategy.verify(inv, &keys)?;
+        strategy.verify(inv, keys)?;
         Ok(())
     }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -68,7 +68,7 @@ pub trait Provider {
         role: SignatureRole,
         secret_key: &SecretKeyEntry,
     ) -> Result<()> {
-        inv.sign(secret_key.label.clone(), role, secret_key)?;
+        inv.sign(role, secret_key)?;
         Ok(())
     }
 
@@ -78,7 +78,7 @@ pub trait Provider {
         strategy: VerificationStrategy,
         keys: Vec<super::signature::PublicKey>,
     ) -> Result<()> {
-        strategy.verify(inv, keys)?;
+        strategy.verify(inv, &keys)?;
         Ok(())
     }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -34,6 +34,23 @@ use crate::Id;
 /// A custom shorthand result type that always has an error type of [`ProviderError`](ProviderError)
 pub type Result<T> = core::result::Result<T, ProviderError>;
 
+pub trait Strategy {
+    fn validate(&self, inv: &Invoice) -> Result<()>;
+}
+
+pub struct BasicStrategy {
+    keychain: String,
+    verify_all: bool,
+}
+
+impl BasicStrategy {
+    pub fn new(keychain: String, roles: Vec<SignatureRole>) -> Self {}
+}
+
+pub trait KeyLoader {
+    fn load(&self) -> Result<SecretKeyFile>;
+}
+
 /// The basic functionality required for a Bindle provider.
 ///
 /// Please note that due to this being an `async_trait`, the types might look complicated. Look at
@@ -51,7 +68,13 @@ pub trait Provider {
     ///
     /// It must verify that each referenced parcel is present in storage. Any parcel that is not
     /// present must be returned in the list of labels.
-    async fn create_invoice(&self, inv: &super::Invoice) -> Result<Vec<super::Label>>;
+    async fn create_invoice(
+        &self,
+        inv: &super::Invoice,
+        role: SignatureRole,
+        key: TryInto<SecretKeyFile>,
+        verification_strategy: VerificationStrategy,
+    ) -> Result<Vec<super::Label>>;
 
     /// Load an invoice and return it
     ///

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -32,11 +32,15 @@ impl Provider for Proxy {
         inv: &mut crate::Invoice,
         _role: SignatureRole,
         secret_key: &SecretKeyEntry,
-        strategy: VerificationStrategy,
+        _strategy: VerificationStrategy,
     ) -> Result<Vec<crate::Label>> {
-        // TODO: Need a way to load the local public keyring
-        let keyring = KeyRing::default();
-        strategy.verify(inv, &keyring)?;
+        // TODO: When we add proxy support as part of #141, we need to also add
+        // proxy verification here. We'll need to get the keyring and then do
+        // the verification using the official keyring. But we might need to
+        // add logic to ensure that the upstream proxy is remote, because if it is
+        // local we don't need to verify here.
+        // let keyring = KeyRing::default();
+        // strategy.verify(inv, &keyring)?;
 
         let mut inv2 = inv.to_owned();
         self.sign_invoice(&mut inv2, SignatureRole::Proxy, secret_key)?;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -36,7 +36,7 @@ impl Provider for Proxy {
     ) -> Result<Vec<crate::Label>> {
         // TODO: Need a way to load the local public keyring
         let keyring = vec![];
-        strategy.verify(inv, keyring)?;
+        strategy.verify(inv, &keyring)?;
 
         let mut inv2 = inv.to_owned();
         self.sign_invoice(&mut inv2, SignatureRole::Proxy, secret_key)?;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -10,7 +10,7 @@ use crate::provider::{Provider, ProviderError, Result};
 use crate::Id;
 use crate::{
     client::{Client, ClientError},
-    signature::{KeyRing, SignatureRole},
+    signature::SignatureRole,
     SecretKeyEntry, VerificationStrategy,
 };
 

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -10,7 +10,7 @@ use crate::provider::{Provider, ProviderError, Result};
 use crate::Id;
 use crate::{
     client::{Client, ClientError},
-    signature::SignatureRole,
+    signature::{KeyRing, SignatureRole},
     SecretKeyEntry, VerificationStrategy,
 };
 
@@ -35,7 +35,7 @@ impl Provider for Proxy {
         strategy: VerificationStrategy,
     ) -> Result<Vec<crate::Label>> {
         // TODO: Need a way to load the local public keyring
-        let keyring = vec![];
+        let keyring = KeyRing::default();
         strategy.verify(inv, &keyring)?;
 
         let mut inv2 = inv.to_owned();

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -55,6 +55,12 @@ pub mod v1 {
         accept_header: Option<String>,
     ) -> Result<impl warp::Reply, Infallible> {
         let accept = accept_header.unwrap_or_default();
+        trace!("Create invoice request with invoice: {:?}", inv);
+
+        // Right here, I need to load one secret key and a ring of public keys.
+        // Then I need to validate the invoice against the public keys, sign the invoice
+        // with my private key, and THEN go on to store.create_invoice()
+
         let labels = match store.create_invoice(&inv).await {
             Ok(l) => l,
             Err(e) => {

--- a/src/server/reply.rs
+++ b/src/server/reply.rs
@@ -121,6 +121,7 @@ pub fn into_reply(error: ProviderError) -> warp::reply::WithStatus<SerializedDat
         #[cfg(feature = "client")]
         ProviderError::ProxyError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         ProviderError::Other(_) | ProviderError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        ProviderError::FailedSigning(_) => StatusCode::BAD_REQUEST,
     };
 
     reply_from_error(error, status_code)

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -4,15 +4,17 @@ use crate::server::filters;
 
 /// A helper function that aggregates all routes into a complete API filter. If you only wish to
 /// serve specific endpoints or versions, you can assemble them with the individual submodules
-pub fn api<P, I, Authn, Authz>(
+pub fn api<P, I, Authn, Authz, S>(
     store: P,
     index: I,
     authn: Authn,
     authz: Authz,
+    secret_store: S,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone
 where
     P: crate::provider::Provider + Clone + Send + Sync + 'static,
     I: crate::search::Search + Clone + Send + Sync + 'static,
+    S: crate::invoice::signature::SecretKeyStorage + Clone + Send + Sync,
     Authn: crate::authn::Authenticator + Clone + Send + Sync + 'static,
     Authz: crate::authz::Authorizer + Clone + Send + Sync + 'static,
 {
@@ -21,8 +23,14 @@ where
         .untuple_one()
         .and(
             v1::invoice::query(index)
-                .or(v1::invoice::create_toml(store.clone()))
-                .or(v1::invoice::create_json(store.clone()))
+                .or(v1::invoice::create_toml(
+                    store.clone(),
+                    secret_store.clone(),
+                ))
+                .or(v1::invoice::create_json(
+                    store.clone(),
+                    secret_store.clone(),
+                ))
                 .or(v1::invoice::get(store.clone()))
                 .or(v1::invoice::head(store.clone()))
                 .or(v1::invoice::yank(store.clone()))
@@ -46,6 +54,8 @@ pub mod v1 {
     use warp::Filter;
 
     pub mod invoice {
+        use crate::{server::routes::with_secret_store, signature::SecretKeyStorage};
+
         use super::*;
 
         pub fn query<S>(
@@ -62,31 +72,37 @@ pub mod v1 {
                 .and_then(query_invoices)
         }
 
-        pub fn create_toml<P>(
+        pub fn create_toml<P, S>(
             store: P,
+            secret_store: S,
         ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone
         where
             P: Provider + Clone + Send + Sync,
+            S: SecretKeyStorage + Clone + Send + Sync,
         {
             warp::path("_i")
                 .and(warp::path::end())
                 .and(warp::post())
                 .and(with_store(store))
+                .and(with_secret_store(secret_store))
                 .and(filters::toml())
                 .and(warp::header::optional::<String>("accept"))
                 .and_then(create_invoice)
                 .recover(filters::handle_deserialize_rejection)
         }
-        pub fn create_json<P>(
+        pub fn create_json<P, S>(
             store: P,
+            secret_store: S,
         ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone
         where
             P: Provider + Clone + Send + Sync,
+            S: SecretKeyStorage + Clone + Send + Sync,
         {
             warp::path("_i")
                 .and(warp::path::end())
                 .and(warp::post())
                 .and(with_store(store))
+                .and(with_secret_store(secret_store))
                 .and(warp::body::json())
                 .and(warp::header::optional::<String>("accept"))
                 .and_then(create_invoice)
@@ -205,6 +221,16 @@ pub(crate) fn with_store<P>(
 ) -> impl Filter<Extract = (P,), Error = std::convert::Infallible> + Clone
 where
     P: crate::provider::Provider + Clone + Send,
+{
+    // We have to clone for this to be Fn instead of FnOnce
+    warp::any().map(move || store.clone())
+}
+
+pub(crate) fn with_secret_store<P>(
+    store: P,
+) -> impl Filter<Extract = (P,), Error = std::convert::Infallible> + Clone
+where
+    P: crate::invoice::signature::SecretKeyStorage + Clone + Send,
 {
     // We have to clone for this to be Fn instead of FnOnce
     warp::any().map(move || store.clone())

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -11,6 +11,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use crate::invoice::signature::KeyRing;
 use crate::provider::file::FileProvider;
 use crate::search::StrictEngine;
 
@@ -155,7 +156,7 @@ impl From<RawScaffold> for Scaffold {
 pub async fn setup() -> (FileProvider<StrictEngine>, StrictEngine) {
     let temp = tempdir().expect("unable to create tempdir");
     let index = StrictEngine::default();
-    let store = FileProvider::new(temp.path().to_owned(), index.clone()).await;
+    let store = FileProvider::new(temp.path().to_owned(), index.clone(), KeyRing::default()).await;
     (store, index)
 }
 


### PR DESCRIPTION
This PR wires up all of the signing and verification logic for the server.

Todo:

- [x] Unit test for VerificationStrategy
- [ ] ~~Implementation for Proxy: Sign before sending upstream.~~ Moved to #141
- [x] Implementation for LRU
- [x] Remove `Invoice::verify()`, since that is now on VerificationStrategy
- [x] API server needs to be able to load keyfiles
- [ ] ~~API server needs to be able to load strategy~~ Moved to #143
- [x] File provider needs to load public keyring
- [x] Attempt to remove Dalek from public API