### PR TITLE
chore(*): Switches to the `tracing` crate and instruments all server things

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,12 +7,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.15"
+name = "ansi_term"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "memchr",
+ "winapi",
 ]
 
 [[package]]
@@ -78,10 +78,8 @@ dependencies = [
  "clap",
  "dirs",
  "ed25519-dalek",
- "env_logger",
  "futures",
  "hyper",
- "log",
  "lru",
  "mime",
  "mime_guess",
@@ -97,6 +95,9 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
  "url",
  "warp",
 ]
@@ -166,6 +167,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -310,19 +323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -585,12 +585,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +823,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1140,10 +1162,17 @@ version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
- "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1388,6 +1417,15 @@ dependencies = [
  "cpuid-bool",
  "digest",
  "opaque-debug",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1669,7 +1707,19 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1689,6 +1739,49 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ server = ["warp"]
 client = ["reqwest", "mime_guess", "dirs"]
 caching = []
 test-tools = []
-cli = ["clap"]
+cli = ["clap", "tracing-subscriber"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -56,14 +56,15 @@ clap = { version = "3.0.0-beta.2", optional = true }
 reqwest = { version = "0.11", features = ["stream"], optional = true }
 hyper = "0.14"
 url = "2.2"
-log = "0.4"
-env_logger = "0.8"
+tracing-subscriber = { version = "0.2", optional = true }
 dirs = { version = "3.0", optional = true }
 mime_guess = { version = "2.0", optional = true }
 lru = "0.6"
 rand = "0.7"
 ed25519-dalek = "1.0"
 base64 = "0.13"
+tracing = { version = "0.1", features = ["log"] }
+tracing-futures = "0.2"
 
 [dev-dependencies]
 mime = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-SERVER_FEATURES ?= "--all-features"
-SERVER_BIN := "bindle-server"
-CLIENT_FEATURES ?= "--features=cli"
-CLIENT_BIN := "bindle"
-BINDLE_LOG_LEVEL ?= "debug"
+SERVER_FEATURES ?= --all-features
+SERVER_BIN := bindle-server
+CLIENT_FEATURES ?= --features=cli
+CLIENT_BIN := bindle
+BINDLE_LOG_LEVEL ?= debug
+
+export RUST_LOG=error,warp=info,bindle=${BINDLE_LOG_LEVEL}
 
 .PHONY: test
 test:
@@ -10,7 +12,6 @@ test:
 
 .PHONY: serve
 serve:
-	RUST_LOG=debug,bindle::*=${BINDLE_LOG_LEVEL}\ 
 	cargo run ${SERVER_FEATURES} --bin ${SERVER_BIN}
 
 # Sort of a wacky hack if you want to do `$(make client) --help`

--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -12,12 +12,12 @@ use bindle::{
 };
 
 use clap::Clap;
-use log::{info, warn};
 use sha2::Digest;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 use tokio_stream::StreamExt;
 use tokio_util::io::StreamReader;
+use tracing::log::{info, warn};
 
 mod opts;
 
@@ -26,8 +26,8 @@ use opts::*;
 #[tokio::main]
 async fn main() -> std::result::Result<(), ClientError> {
     let opts = opts::Opts::parse();
-    // TODO: Allow log level setting
-    env_logger::init();
+    // TODO: Allow log level setting outside of RUST_LOG (this is easier with this subscriber)
+    tracing_subscriber::fmt::init();
 
     let bindle_client = Client::new(&opts.server_url)?;
     let bindle_dir = opts

--- a/src/cache/dumb.rs
+++ b/src/cache/dumb.rs
@@ -1,8 +1,8 @@
 //! A cache that doesn't ever expire entries, generally for use by a client storing bindles on disk
 use std::convert::TryInto;
 
-use log::{info, warn};
 use tokio_stream::{Stream, StreamExt};
+use tracing::log::{info, warn};
 
 use super::{into_cache_result, Cache};
 use crate::provider::{Provider, ProviderError, Result};

--- a/src/cache/lru.rs
+++ b/src/cache/lru.rs
@@ -3,7 +3,6 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use ::lru::LruCache as Lru;
-use log::{debug, trace};
 use tempfile::NamedTempFile;
 use tokio::fs::File;
 use tokio::io::AsyncSeekExt;
@@ -13,6 +12,7 @@ use tokio_util::{
     codec::{BytesCodec, FramedRead},
     io::StreamReader,
 };
+use tracing::log::{debug, trace};
 
 use super::*;
 use crate::provider::{Provider, ProviderError, Result};

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 pub enum ClientError {
     /// Indicates that the given URL is invalid, contains the underlying parsing error
     #[error("Invalid URL given: {0:?}")]
-    InvalidURL(#[from] url::ParseError),
+    InvalidUrl(#[from] url::ParseError),
     /// Invalid configuration was given to the client
     #[error("Invalid configuration: {0}")]
     InvalidConfig(String),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,11 +7,11 @@ pub mod load;
 use std::convert::TryInto;
 use std::path::Path;
 
-use log::{debug, info};
 use reqwest::header;
 use reqwest::Client as HttpClient;
 use reqwest::{Body, RequestBuilder, StatusCode};
 use tokio_stream::{Stream, StreamExt};
+use tracing::log::{debug, info};
 use url::Url;
 
 use crate::Id;

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -265,7 +265,7 @@ fn version_compare(version: &Version, requirement: &str) -> bool {
             return req.matches(version);
         }
         Err(e) => {
-            log::error!("SemVer range could not parse: {}", e);
+            tracing::log::error!("SemVer range could not parse: {}", e);
         }
     }
     false

--- a/src/invoice/signature.rs
+++ b/src/invoice/signature.rs
@@ -138,7 +138,7 @@ impl KeyEntry {
     pub fn verify_label(self, key: PublicKey) -> anyhow::Result<()> {
         match self.label_signature {
             None => {
-                log::info!("Label was not signed. Skipping.");
+                tracing::log::info!("Label was not signed. Skipping.");
                 Ok(())
             }
             Some(txt) => {
@@ -184,7 +184,7 @@ impl SecretKeyEntry {
             SignatureError::CorruptKey("Base64 decoding of the keypair failed".to_owned())
         })?;
         let keypair = Keypair::from_bytes(&rawbytes).map_err(|e| {
-            log::error!("Error loading key: {}", e);
+            tracing::log::error!("Error loading key: {}", e);
             // Don't leak information about the key, because this could be sent to
             // a remote. A generic error is all the user should see.
             SignatureError::CorruptKey("Could not load keypair".to_owned())

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -94,8 +94,8 @@ pub trait Search {
     /// or if the search engine itself fails to process the query.
     async fn query(
         &self,
-        term: String,
-        filter: String,
+        term: &str,
+        filter: &str,
         options: SearchOptions,
     ) -> anyhow::Result<Matches>;
 

--- a/src/search/noop.rs
+++ b/src/search/noop.rs
@@ -10,11 +10,11 @@ pub struct NoopEngine {}
 impl Search for NoopEngine {
     async fn query(
         &self,
-        term: String,
-        _filter: String,
+        term: &str,
+        _filter: &str,
         options: SearchOptions,
     ) -> anyhow::Result<Matches> {
-        Ok(Matches::new(&options, term))
+        Ok(Matches::new(&options, term.to_owned()))
     }
 
     async fn index(&self, _: &crate::Invoice) -> anyhow::Result<()> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -11,6 +11,8 @@ mod routes;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
+use tracing::debug;
+
 use super::provider::Provider;
 use crate::search::Search;
 
@@ -45,12 +47,17 @@ where
     let server = warp::serve(api);
     match tls {
         None => {
+            debug!("No TLS config found, starting server in HTTP mode");
             server
                 .try_bind_with_graceful_shutdown(addr, shutdown_signal())?
                 .1
                 .await
         }
         Some(config) => {
+            debug!(
+                ?config.key_path,
+                ?config.cert_path, "Got TLS config, starting server in HTTPS mode",
+            );
             server
                 .tls()
                 .key_path(config.key_path)

--- a/src/server/reply.rs
+++ b/src/server/reply.rs
@@ -13,7 +13,7 @@ where
 {
     Toml {
         inner: toml::to_vec(val).map_err(|e| {
-            log::error!("Error while serializing TOML: {:?}", e);
+            tracing::log::error!("Error while serializing TOML: {:?}", e);
         }),
     }
 }

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -33,6 +33,7 @@ where
         .recover(filters::handle_invalid_request_path)
         .recover(filters::handle_authn_rejection)
         .recover(filters::handle_authz_rejection)
+        .with(warp::trace::request())
 }
 
 pub mod v1 {

--- a/src/standalone/mod.rs
+++ b/src/standalone/mod.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::path::{Path, PathBuf};
 
-use log::{debug, info};
 use tokio::io::{AsyncRead, AsyncWriteExt};
 use tokio_stream::{Stream, StreamExt};
+use tracing::log::{debug, info};
 
 use crate::client::{Client, ClientError, Result};
 use crate::Id;
@@ -120,7 +120,7 @@ impl StandaloneRead {
 /// submitted one could be incorrect (intentionally or unintentionally)
 async fn create_or_get_invoice(
     client: &Client,
-    invoice_path: &PathBuf,
+    invoice_path: &Path,
 ) -> Result<crate::InvoiceCreateResponse> {
     // Load the invoice into memory so we can have access to its ID for fetching if needed
     let inv: crate::Invoice = crate::client::load::toml(invoice_path).await?;


### PR DESCRIPTION
This adds _a lot_ more tracing and instrumentation on most of the major functions
used for the server. It also adds in tracing to the warp processing pipeline, which
should help with debugging. The client code still needs to be updated with more logs
and with instrumentation, but I will do that in a follow up.

Please note that if you think the logs are too verbose or you don't like the format,
tracing is very very tweakable, so we can iterate on this and change it