### PR TITLE
add Accept-type negotiation for JSON and TOML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ SERVER_BIN := bindle-server
 CLIENT_FEATURES ?= --features=cli
 CLIENT_BIN := bindle
 BINDLE_LOG_LEVEL ?= debug
+BINDLE_ID ?= enterprise.com/warpcore/1.0.0
+MIME ?= "application/toml"
 
 export RUST_LOG=error,warp=info,bindle=${BINDLE_LOG_LEVEL}
 
@@ -30,3 +32,4 @@ build-server:
 .PHONY: build-client
 build-client:
 	cargo build ${CLIENT_FEATURES} --bin ${CLIENT_BIN}
+

--- a/bin/server.rs
+++ b/bin/server.rs
@@ -63,7 +63,9 @@ struct Opts {
 async fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
     // TODO: Allow log level setting outside of RUST_LOG (this is easier with this subscriber)
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
 
     // load config file if it exists
     let config_file_path = match opts.config_file {

--- a/src/server/filters.rs
+++ b/src/server/filters.rs
@@ -9,7 +9,7 @@ use tracing_futures::Instrument;
 use warp::reject::{custom, Reject, Rejection};
 use warp::Filter;
 
-use super::TOML_MIME_TYPE;
+use super::{JSON_MIME_TYPE, TOML_MIME_TYPE};
 use crate::authn::Authenticator;
 use crate::authz::Authorizer;
 
@@ -204,6 +204,21 @@ async fn parse_toml<T: DeserializeOwned + Send>(buf: impl warp::Buf) -> Result<T
         warn!("Failed to deserialize TOML file: {}", err);
         custom(BodyDeserializeError { cause: err.into() })
     })
+}
+
+pub fn json<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
+    warp::filters::header::exact_ignore_case("Content-Type", JSON_MIME_TYPE)
+        .and(warp::body::aggregate())
+        .and_then(parse_json)
+}
+
+async fn parse_json<T: DeserializeOwned + Send>(buf: impl warp::Buf) -> Result<T, Rejection> {
+    debug!("Parsing as JSON");
+    let mut raw = Vec::new();
+    buf.reader()
+        .read_to_end(&mut raw)
+        .map_err(|err| custom(BodyDeserializeError { cause: err.into() }))?;
+    serde_json::from_slice(&raw).map_err(|err| custom(BodyDeserializeError { cause: err.into() }))
 }
 
 #[instrument(level = "trace", skip(err))]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -25,9 +25,9 @@ pub mod v1 {
         let term = options.query.clone().unwrap_or_default();
         let version = options.version.clone().unwrap_or_default();
         debug!(
-            "Querying with term {} and version{}",
-            term.clone(),
-            version.clone()
+            %term,
+            %version,
+            "Querying invoice index",
         );
         let matches = match index.query(&term, &version, options.into()).await {
             Ok(m) => m,
@@ -106,7 +106,6 @@ pub mod v1 {
     ) -> Result<Box<dyn warp::Reply>, Infallible> {
         let accept = accept_header.unwrap_or_default();
 
-        debug!("Accept header is {}", accept.clone());
         let res = if query.yanked.unwrap_or_default() {
             store.get_yanked_invoice(id)
         } else {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,6 +17,7 @@ use super::provider::Provider;
 use crate::search::Search;
 
 pub(crate) const TOML_MIME_TYPE: &str = "application/toml";
+pub(crate) const JSON_MIME_TYPE: &str = "application/json";
 
 /// The configuration required for running with TLS enabled
 pub struct TlsConfig {

--- a/src/server/reply.rs
+++ b/src/server/reply.rs
@@ -1,11 +1,104 @@
 use serde::Serialize;
+use warp::http::header::HeaderValue;
 use warp::http::status::StatusCode;
 use warp::reply::Response;
 use warp::Reply;
 
-use super::TOML_MIME_TYPE;
+use tracing::log::debug;
+
+use super::{JSON_MIME_TYPE, TOML_MIME_TYPE};
 use crate::provider::ProviderError;
 
+/// Use an accept header to determine how to serialize content.
+///
+/// This will examine the Accept header, looking for the best match, and then it will
+/// use the appropriate serializer to serialize the data.
+///
+/// The current implementation ignores `q=` annotations, assigning preference based on
+/// the first MIME type to match.
+///
+/// For example, `Accept: text/json, application/toml;q=0.9` will cause encoding to be in JSON.
+/// If no suitable content type is found, this will encode in application/toml, as that
+/// is the behavior described in the spec.
+pub fn serialized_data<T>(val: &T, accept: String) -> SerializedData
+where
+    T: Serialize,
+{
+    let supported = vec![
+        TOML_MIME_TYPE.to_owned(),
+        JSON_MIME_TYPE.to_owned(),
+        "text/json".to_owned(),
+    ];
+    let default_mime = "*/*".to_owned();
+    let accept_items = parse_accept(accept.clone());
+    debug!(
+        "Parsed accept header '{}' into items: {:?}",
+        accept, accept_items
+    );
+    let best_fit = accept_items
+        .iter()
+        .find(|i| supported.contains(*i))
+        .unwrap_or(&default_mime);
+    debug!("Best fit MIME is {}", best_fit);
+    let mut final_mime = TOML_MIME_TYPE;
+    let inner = match (*best_fit).as_str() {
+        JSON_MIME_TYPE | "text/json" => {
+            final_mime = JSON_MIME_TYPE;
+            serde_json::to_vec(val).map_err(|e| {
+                tracing::log::error!("Error while serializing TOML: {:?}", e);
+            })
+        }
+        // TOML is default
+        _ => toml::to_vec(val).map_err(|e| {
+            tracing::log::error!("Error while serializing TOML: {:?}", e);
+        }),
+    };
+    debug!("negotiated MIME is '{}'", final_mime);
+    SerializedData {
+        inner,
+        mime: final_mime.to_owned(),
+    }
+}
+
+fn parse_accept<'a>(header: String) -> Vec<String> {
+    header
+        .split(',')
+        .map(|h| {
+            let normalized = h.trim().to_lowercase();
+            let parts: Vec<&str> = normalized.split(";").collect();
+            let mime = parts[0].clone();
+            mime.to_owned()
+        })
+        .collect()
+}
+
+/// A serialized body.
+///
+/// Currently, this may be JSON or TOML.
+pub struct SerializedData {
+    inner: Result<Vec<u8>, ()>,
+    mime: String,
+}
+
+impl Reply for SerializedData {
+    #[inline]
+    fn into_response(self) -> Response {
+        match self.inner {
+            Ok(body) => {
+                let mut res = Response::new(body.into());
+                res.headers_mut().insert(
+                    warp::http::header::CONTENT_TYPE,
+                    HeaderValue::from_str(self.mime.as_str())
+                        .unwrap_or(HeaderValue::from_static(TOML_MIME_TYPE)),
+                );
+                res
+            }
+            Err(()) => warp::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        }
+    }
+}
+
+/*
 // Borrowed and modified from https://docs.rs/warp/0.2.5/src/warp/reply.rs.html#102
 pub fn toml<T>(val: &T) -> Toml
 where
@@ -39,13 +132,14 @@ impl Reply for Toml {
         }
     }
 }
+*/
 
 /// A helper function for converting a [`ProviderError`](crate::provider::ProviderError) into a Warp
 /// `Reply` with the proper status code. It will return a TOML body that looks like:
 /// ```toml
 /// error = "bindle is yanked"
 /// ```
-pub fn into_reply(error: ProviderError) -> warp::reply::WithStatus<Toml> {
+pub fn into_reply(error: ProviderError) -> warp::reply::WithStatus<SerializedData> {
     let mut error = error;
     let status_code = match &error {
         ProviderError::CreateYanked => StatusCode::UNPROCESSABLE_ENTITY,
@@ -74,11 +168,36 @@ pub fn into_reply(error: ProviderError) -> warp::reply::WithStatus<Toml> {
 pub fn reply_from_error(
     error: impl std::string::ToString,
     status_code: warp::http::StatusCode,
-) -> warp::reply::WithStatus<Toml> {
+) -> warp::reply::WithStatus<SerializedData> {
     warp::reply::with_status(
-        toml(&crate::ErrorResponse {
-            error: error.to_string(),
-        }),
+        serialized_data(
+            &crate::ErrorResponse {
+                error: error.to_string(),
+            },
+            TOML_MIME_TYPE.to_owned(),
+        ),
         status_code,
     )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_parse_accept() {
+        assert_eq!(
+            vec!["application/toml"],
+            parse_accept("application/toml".to_owned())
+        );
+
+        assert_eq!(
+            vec!["application/toml"],
+            parse_accept("application/TOML".to_owned())
+        );
+
+        assert_eq!(
+            vec!["text/json", "application/json"],
+            parse_accept("text/json, application/json;q=0.9".to_owned())
+        );
+    }
 }

--- a/src/server/reply.rs
+++ b/src/server/reply.rs
@@ -98,42 +98,6 @@ impl Reply for SerializedData {
     }
 }
 
-/*
-// Borrowed and modified from https://docs.rs/warp/0.2.5/src/warp/reply.rs.html#102
-pub fn toml<T>(val: &T) -> Toml
-where
-    T: Serialize,
-{
-    Toml {
-        inner: toml::to_vec(val).map_err(|e| {
-            tracing::log::error!("Error while serializing TOML: {:?}", e);
-        }),
-    }
-}
-
-/// A JSON formatted reply.
-pub struct Toml {
-    inner: Result<Vec<u8>, ()>,
-}
-
-impl Reply for Toml {
-    #[inline]
-    fn into_response(self) -> Response {
-        match self.inner {
-            Ok(body) => {
-                let mut res = Response::new(body.into());
-                res.headers_mut().insert(
-                    warp::http::header::CONTENT_TYPE,
-                    warp::http::header::HeaderValue::from_static(TOML_MIME_TYPE),
-                );
-                res
-            }
-            Err(()) => warp::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-        }
-    }
-}
-*/
-
 /// A helper function for converting a [`ProviderError`](crate::provider::ProviderError) into a Warp
 /// `Reply` with the proper status code. It will return a TOML body that looks like:
 /// ```toml

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -87,7 +87,7 @@ pub mod v1 {
                 .and(warp::path::end())
                 .and(warp::post())
                 .and(with_store(store))
-                .and(filters::json())
+                .and(warp::body::json())
                 .and(warp::header::optional::<String>("accept"))
                 .and_then(create_invoice)
                 .recover(filters::handle_deserialize_rejection)


### PR DESCRIPTION
Add content negotiation for JSON and TOML.

This adds support for using the `Accept` header to try to find the best format for sending results back. In addition, it accepts `invoice.json` content if the `content-type` is one of `text/json` or `application/json`.

Closes #132

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>