### PR TITLE
fix strict query processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 
 .PHONY: serve
 serve:
-	cargo run ${SERVER_FEATURES} --bin ${SERVER_BIN}
+	cargo run ${SERVER_FEATURES} --bin ${SERVER_BIN} -- --directory ${HOME}/.bindle/bindles
 
 # Sort of a wacky hack if you want to do `$(make client) --help`
 .PHONY: client
@@ -30,4 +30,3 @@ build-server:
 .PHONY: build-client
 build-client:
 	cargo build ${CLIENT_FEATURES} --bin ${CLIENT_BIN}
-	

--- a/src/search/strict.rs
+++ b/src/search/strict.rs
@@ -42,9 +42,11 @@ impl Search for StrictEngine {
             .await
             .iter()
             .filter(|(_, i)| {
-                // Term and version have to be exact matches.
-                // TODO: Version should have matching turned on.
-                i.bindle.id.name() == term && i.version_in_range(filter)
+                // Per the spec:
+                // - if `term` is present, then it must be contained within the name field of the bindle.
+                // - if a version filter is present, then the version of the bindle must abide by the filter.
+                debug!(term, filter, "comparing term and filter");
+                i.bindle.id.name().contains(term) && (filter == "" || i.version_in_range(filter))
             })
             .map(|(_, v)| (*v).clone())
             .collect();


### PR DESCRIPTION
The previous implementation of search was stricter than the specification required. This relaxes strict processing.

The following should now work:

- an empty query
- an empty version filter
- a query whose term is a substring (e.g. `warp` should now match `enterprise.com/warpcore/1.0.0`)

Closes #98

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>