### PR TITLE
fixed the help text for the search -q param

### DIFF
--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -161,7 +161,7 @@ pub struct Search {
     #[clap(
         short = 'q',
         long = "query",
-        about = "name of the bindle to search for, an empty query means all bindles"
+        about = "filter bindles by this query. Typically, the query is a bindle name or part of a name"
     )]
     pub query: Option<String>,
     #[clap(short = 'b', long = "bindle-version", about = "version constraint of the bindle to search for", long_about = VERSION_QUERY)]


### PR DESCRIPTION
This fixes the help text for the `bindle search`'s `-q` option.

Before, the text erroneously said that `-q ""` would return all results. Attempting this would result in an error. In practice, merely omitting the optional `-q` flag is sufficient to get all results.

It also erroneously stated that the query had to be the name of the bindle. In strict mode, the query must be part of the name. But in standard mode, the query could be applied to authors, description, version, and other fields as well.

Closes #124

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>