### PR TITLE
fix(server): Respects RUST_LOG variable

### DIFF
--- a/bin/server.rs
+++ b/bin/server.rs
@@ -65,6 +65,7 @@ async fn main() -> anyhow::Result<()> {
     // TODO: Allow log level setting outside of RUST_LOG (this is easier with this subscriber)
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
     // load config file if it exists


### PR DESCRIPTION
I found out that krustlet wasn't respecting it for the same reason, so
I added the change here as well