### PR TITLE
add a convenience method for checking if the parcel is in the default group

### DIFF
--- a/src/invoice/condition.rs
+++ b/src/invoice/condition.rs
@@ -9,3 +9,9 @@ pub struct Condition {
     pub member_of: Option<Vec<String>>,
     pub requires: Option<Vec<String>>,
 }
+
+impl Condition {
+    pub fn in_default_group(&self) -> bool {
+        return self.member_of.is_none();
+    }
+}


### PR DESCRIPTION
This is helpful for higher-level usage like Wagi

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>