### PR TITLE
add a group_members function on invoice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CLIENT_FEATURES ?= --features=cli
 CLIENT_BIN := bindle
 BINDLE_LOG_LEVEL ?= debug
 BINDLE_ID ?= enterprise.com/warpcore/1.0.0
+BINDLE_IFACE ?= 127.0.0.1:8080
 MIME ?= "application/toml"
 
 export RUST_LOG=error,warp=info,bindle=${BINDLE_LOG_LEVEL}
@@ -14,7 +15,7 @@ test:
 
 .PHONY: serve
 serve:
-	cargo run ${SERVER_FEATURES} --bin ${SERVER_BIN} -- --directory ${HOME}/.bindle/bindles
+	cargo run ${SERVER_FEATURES} --bin ${SERVER_BIN} -- --directory ${HOME}/.bindle/bindles --address ${BINDLE_IFACE}
 
 # Sort of a wacky hack if you want to do `$(make client) --help`
 .PHONY: client

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -99,7 +99,7 @@ impl Invoice {
 
     /// Check whether a group by this name is present.
     pub fn has_group(&self, name: &str) -> bool {
-        let empty = vec![];
+        let empty = Vec::with_capacity(0);
         self.group
             .as_ref()
             .unwrap_or(&empty)

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -99,18 +99,18 @@ impl Invoice {
 
     /// Check whether a group by this name is present.
     pub fn has_group(&self, name: &str) -> bool {
+        let empty = vec![];
         self.group
-            .clone()
-            .unwrap_or_default()
+            .as_ref()
+            .unwrap_or(&empty)
             .iter()
-            .find(|g| g.name == name)
-            .is_some()
+            .any(|g| g.name == name)
     }
 
     /// Get all of the parcels on the given group.
     pub fn group_members(&self, name: &str) -> Vec<Parcel> {
         // If there is no such group, return early.
-        if self.has_group(name) {
+        if !self.has_group(name) {
             info!(name, "no such group");
             return vec![];
         }
@@ -619,7 +619,7 @@ mod test {
         version = "1.2.3"
 
         [[group]]
-        name = "images"
+        name = "telescopes"
 
         [[parcel]]
         [parcel.label]

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -27,6 +27,7 @@ pub use signature::{Signature, SignatureError, SignatureRole};
 use ed25519_dalek::{Keypair, PublicKey, Signature as EdSignature, Signer};
 use semver::{Compat, Version, VersionReq};
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 use std::collections::BTreeMap;
 use std::convert::TryInto;
@@ -96,9 +97,24 @@ impl Invoice {
         version_compare(self.bindle.id.version(), requirement)
     }
 
+    /// Check whether a group by this name is present.
+    pub fn has_group(&self, name: &str) -> bool {
+        self.group
+            .clone()
+            .unwrap_or_default()
+            .iter()
+            .find(|g| g.name == name)
+            .is_some()
+    }
+
     /// Get all of the parcels on the given group.
     pub fn group_members(&self, name: &str) -> Vec<Parcel> {
-        // TODO: This does not enforce that there is actually a group entry.
+        // If there is no such group, return early.
+        if self.has_group(name) {
+            info!(name, "no such group");
+            return vec![];
+        }
+
         self.parcel
             .clone()
             .unwrap_or_default()


### PR DESCRIPTION
This adds a `group_members(name)` function on the invoice so that it is easy to get all of the parcels that belong to a group.

Ported over from Wagi.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>