### PR TITLE
Reworked error output for ID and SemVer parse errors

### DIFF
--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -31,7 +31,7 @@ async fn main() {
     if let Err(e) = run().await.map_err(|e| anyhow::Error::new(e)) {
         eprintln!("{}", e);
         for (i, cause) in e.chain().enumerate() {
-            // Skip the first message
+            // Skip the first message because it is printed above.
             if i > 0 {
                 if i == 1 {
                     eprintln!("\nError trace:");

--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -14,6 +14,7 @@ use bindle::{
 };
 
 use clap::Clap;
+use futures::TryFutureExt;
 use sha2::Digest;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
@@ -26,7 +27,12 @@ mod opts;
 use opts::*;
 
 #[tokio::main]
-async fn main() -> std::result::Result<(), ClientError> {
+async fn main() -> anyhow::Result<()> {
+    // Trap and format error messages using anyhow's formatter.
+    run().await.map_err(anyhow::Error::new)
+}
+
+async fn run() -> std::result::Result<(), ClientError> {
     let opts = opts::Opts::parse();
     // TODO: Allow log level setting outside of RUST_LOG (this is easier with this subscriber)
     tracing_subscriber::fmt::init();

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -4,26 +4,26 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ClientError {
     /// Indicates that the given URL is invalid, contains the underlying parsing error
-    #[error("Invalid URL given: {0:?}")]
+    #[error("Invalid URL given")]
     InvalidUrl(#[from] url::ParseError),
     /// Invalid configuration was given to the client
     #[error("Invalid configuration: {0}")]
     InvalidConfig(String),
     /// IO errors from interacting with the file system
-    #[error("Error while performing IO operation: {0:?}")]
+    #[error("Error while performing IO operation")]
     Io(#[from] std::io::Error),
     /// Invalid TOML parsing that can occur when loading an invoice or label from disk
-    #[error("Invalid toml: {0:?}")]
+    #[error("Invalid toml")]
     InvalidToml(#[from] toml::de::Error),
     /// Invalid TOML serialization that can occur when serializing an object to a request
-    #[error("Invalid toml: {0:?}")]
+    #[error("Invalid toml")]
     TomlSerializationError(#[from] toml::ser::Error),
     /// There was a problem with the http client. This is likely not a user issue. Contains the
     /// underlying error
-    #[error("Error creating request: {0:?}")]
+    #[error("Error creating request")]
     HttpClientError(#[from] reqwest::Error),
     /// An invalid ID was given. Returns the underlying parse error
-    #[error("Invalid id: {0:?}")]
+    #[error("Invalid id")]
     InvalidId(#[from] crate::id::ParseError),
 
     // API errors
@@ -55,7 +55,7 @@ pub enum ClientError {
     #[error("User has invalid credentials or is not authorized to access the requested resource")]
     Unauthorized,
 
-    #[error("Signature error: {0:?}")]
+    #[error("Signature error")]
     SignatureError(#[from] crate::invoice::signature::SignatureError),
 
     /// A catch-all for uncategorized errors. Contains an error message describing the underlying

--- a/src/id.rs
+++ b/src/id.rs
@@ -9,10 +9,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ParseError {
-    #[error("Invalid bindle ID {0}. A bindle ID should be NAME/VERSION")]
+    #[error("Invalid bindle ID '{0}'. A bindle ID should be NAME/VERSION")]
     InvalidId(String),
-    // TODO: Add an error message so we can pass through the parse error from semver
-    #[error("ID does not contain a valid semantic version (e.g. 1.2.3): {0}")]
+    #[error("Version {0} is not a valid semantic version (e.g. 1.2.3)")]
     InvalidSemver(String),
 }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -9,11 +9,11 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ParseError {
-    #[error("Invalid ID")]
-    InvalidId,
+    #[error("Invalid bindle ID {0}. A bindle ID should be NAME/VERSION")]
+    InvalidId(String),
     // TODO: Add an error message so we can pass through the parse error from semver
-    #[error("ID does not contain a valid semver")]
-    InvalidSemver,
+    #[error("ID does not contain a valid semantic version (e.g. 1.2.3): {0}")]
+    InvalidSemver(String),
 }
 
 type Result<T> = std::result::Result<T, ParseError>;
@@ -100,7 +100,7 @@ impl FromStr for Id {
         // Every ID should contain at least one separator or it is invalid
         let last_separator_index = match s.rfind(PATH_SEPARATOR) {
             Some(i) => i,
-            None => return Err(ParseError::InvalidId),
+            None => return Err(ParseError::InvalidId(s.to_owned())),
         };
 
         let (name_part, version_part) = s.split_at(last_separator_index);
@@ -109,12 +109,13 @@ impl FromStr for Id {
         let version_part = version_part.trim_start_matches(PATH_SEPARATOR);
 
         if name_part.is_empty() || version_part.is_empty() {
-            return Err(ParseError::InvalidId);
+            let msg = format!("name: '{}', version: '{}'", name_part, version_part);
+            return Err(ParseError::InvalidId(msg));
         }
 
         let version = version_part
             .parse()
-            .map_err(|_| ParseError::InvalidSemver)?;
+            .map_err(|_| ParseError::InvalidSemver(version_part.to_owned()))?;
 
         Ok(Id {
             name: name_part.to_owned(),

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -179,8 +179,8 @@ pub enum ProviderError {
     #[error("resource already exists")]
     Exists,
     /// The error returned when the given `Id` was invalid and unable to be parsed
-    #[error("invalid ID given")]
-    InvalidId,
+    #[error("invalid ID given: {0:?}")]
+    InvalidId(String),
     /// An uploaded parcel does not match the SHA-256 sum provided with its label
     #[error("digest does not match")]
     DigestMismatch,
@@ -214,8 +214,11 @@ pub enum ProviderError {
 
 impl From<ParseError> for ProviderError {
     fn from(e: ParseError) -> ProviderError {
+        let e_msg = e.to_string();
         match e {
-            ParseError::InvalidId | ParseError::InvalidSemver => ProviderError::InvalidId,
+            ParseError::InvalidId(_) | ParseError::InvalidSemver(_) => {
+                ProviderError::InvalidId(e_msg)
+            }
         }
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -30,7 +30,7 @@ use tokio_stream::Stream;
 
 use crate::invoice::{signature::SecretKeyEntry, SignatureRole, VerificationStrategy};
 use crate::Id;
-use crate::{id::ParseError, SignatureError};
+use crate::SignatureError;
 
 /// A custom shorthand result type that always has an error type of [`ProviderError`](ProviderError)
 pub type Result<T> = core::result::Result<T, ProviderError>;
@@ -173,14 +173,14 @@ pub enum ProviderError {
     #[error("resource not found: if an item does not appear in our records, it does not exist!")]
     NotFound,
     /// Any errors that occur due to IO issues. Contains the underlying IO `Error`
-    #[error("resource could not be loaded: {0:?}")]
+    #[error("resource could not be loaded")]
     Io(#[from] std::io::Error),
     /// The resource being created already exists in the system
     #[error("resource already exists")]
     Exists,
     /// The error returned when the given `Id` was invalid and unable to be parsed
-    #[error("invalid ID given: {0:?}")]
-    InvalidId(String),
+    #[error("invalid ID given")]
+    InvalidId(#[from] crate::id::ParseError),
     /// An uploaded parcel does not match the SHA-256 sum provided with its label
     #[error("digest does not match")]
     DigestMismatch,
@@ -193,34 +193,23 @@ pub enum ProviderError {
     /// An error that occurs when the provider implementation uses a proxy and that proxy request
     /// encounters an error. Only available with the `client` feature enabled
     #[cfg(feature = "client")]
-    #[error("proxy error: {0:?}")]
+    #[error("proxy error")]
     ProxyError(#[from] crate::client::ClientError),
 
     /// The data cannot be properly deserialized from TOML
-    #[error("resource is malformed: {0:?}")]
+    #[error("resource is malformed")]
     Malformed(#[from] toml::de::Error),
     /// The data cannot be properly serialized from TOML
-    #[error("resource cannot be stored: {0:?}")]
+    #[error("resource cannot be stored")]
     Unserializable(#[from] toml::ser::Error),
 
-    #[error("failed signature check invoice: {0:?}")]
+    #[error("failed signature check invoice")]
     FailedSigning(#[from] SignatureError),
 
     /// A catch-all for uncategorized errors. Contains an error message describing the underlying
     /// issue
     #[error("{0}")]
     Other(String),
-}
-
-impl From<ParseError> for ProviderError {
-    fn from(e: ParseError) -> ProviderError {
-        let e_msg = e.to_string();
-        match e {
-            ParseError::InvalidId(_) | ParseError::InvalidSemver(_) => {
-                ProviderError::InvalidId(e_msg)
-            }
-        }
-    }
 }
 
 impl From<std::convert::Infallible> for ProviderError {

--- a/src/server/reply.rs
+++ b/src/server/reply.rs
@@ -115,7 +115,7 @@ pub fn into_reply(error: ProviderError) -> warp::reply::WithStatus<SerializedDat
         ProviderError::Malformed(_)
         | ProviderError::Unserializable(_)
         | ProviderError::DigestMismatch
-        | ProviderError::InvalidId
+        | ProviderError::InvalidId(_)
         | ProviderError::SizeMismatch => StatusCode::BAD_REQUEST,
         ProviderError::Yanked => StatusCode::FORBIDDEN,
         #[cfg(feature = "client")]


### PR DESCRIPTION
This results in error output that walks the nested errors and prints the root cause:

```console
$ bindle --server $BINDLE_HOST push foo
Error: Invalid id: InvalidId("foo")

Caused by:
    Invalid bindle ID foo. A bindle ID should be NAME/VERSION

$ bindle --server $BINDLE_HOST push foo/bar/dadsfas
Error: Invalid id: InvalidSemver("dadsfas")

Caused by:
    ID does not contain a valid semantic version (e.g. 1.2.3): dadsfas
```

Closes #159

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>