### PR TITLE
feat(verification): Updates with new verification strategy

### DIFF
--- a/docs/signing-spec.md
+++ b/docs/signing-spec.md
@@ -347,6 +347,11 @@ While not infallible, it can give an early and decisive warning if a package cro
 For example, if a package is signed by an unknown host key, then this package has been hosted on a server outside the chain of trust.
 While this level of scrutiny is not desirable on, say, a public Bindle registry, it may be invaluable to closed and air-gapped networks where the presence of an unknown signature may warn of a misconfiguration.
 
+### Strategy 6: Multiple Attestation Greedy
+
+The same as the Multiple Attestation strategy with the additional requirement that verifying every other signature in the invoice SHOULD be attempted, similar to Greedy.
+
+For example, if validating `creator` and `approver` under normal Multiple Attestation, only signatures with those roles would be validated. Under Multiple Attestation, all other roles would also be validated
 
 ## Yanking Bindles
 

--- a/src/provider/file/mod.rs
+++ b/src/provider/file/mod.rs
@@ -689,7 +689,7 @@ mod test {
                 &mut scaffold.invoice,
                 SignatureRole::Host,
                 &sk,
-                VerificationStrategy::MultipleAttestation(vec![], false),
+                VerificationStrategy::MultipleAttestation(vec![]),
             )
             .await
             .unwrap();
@@ -735,7 +735,7 @@ mod test {
                 &mut scaffold.invoice,
                 SignatureRole::Host,
                 &sk,
-                VerificationStrategy::MultipleAttestation(vec![], false),
+                VerificationStrategy::MultipleAttestation(vec![]),
             )
             .await
             .is_err());
@@ -760,7 +760,7 @@ mod test {
                 &mut scaffold.invoice,
                 SignatureRole::Host,
                 &sk,
-                VerificationStrategy::MultipleAttestation(vec![], false),
+                VerificationStrategy::MultipleAttestation(vec![]),
             )
             .await
             .expect("should be able to create invoice");
@@ -818,7 +818,7 @@ mod test {
                 &mut scaffold.invoice,
                 SignatureRole::Host,
                 &sk,
-                VerificationStrategy::MultipleAttestation(vec![], false),
+                VerificationStrategy::MultipleAttestation(vec![]),
             )
             .await
             .expect("should be able to create an invoice");
@@ -870,7 +870,7 @@ mod test {
                 &mut scaffold.invoice,
                 SignatureRole::Host,
                 &sk,
-                VerificationStrategy::MultipleAttestation(vec![], false),
+                VerificationStrategy::MultipleAttestation(vec![]),
             )
             .await
             .expect("Invoice should be created");
@@ -914,13 +914,13 @@ mod test {
                 &mut inv1,
                 SignatureRole::Host,
                 &sk,
-                VerificationStrategy::MultipleAttestation(vec![], false),
+                VerificationStrategy::MultipleAttestation(vec![]),
             ),
             store.create_invoice(
                 &mut inv2,
                 SignatureRole::Host,
                 &sk,
-                VerificationStrategy::MultipleAttestation(vec![], false),
+                VerificationStrategy::MultipleAttestation(vec![]),
             )
         );
 


### PR DESCRIPTION
As I started to work on #143, I realized that we technically have 2 Mulitple Attestation
strategies that would be better to explicitly document and define rather than having
that behavior defined by a boolean flag. This also has the side effect of making parsing a config
object and command line flag easier to implement for #143