### PR TITLE
SSL/TLS configuration streamlining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.vscode
 .DS_Store
+/ssl-example.*

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINDLE_LOG_LEVEL ?= debug
 BINDLE_ID ?= enterprise.com/warpcore/1.0.0
 BINDLE_IFACE ?= 127.0.0.1:8080
 MIME ?= "application/toml"
-CERT_NAME ?= "./ssl-example"
+CERT_NAME ?= ssl-example
 TLS_OPTS ?= --tls-cert ${CERT_NAME}.crt.pem --tls-key ${CERT_NAME}.key.pem
 
 export RUST_LOG=error,warp=info,bindle=${BINDLE_LOG_LEVEL}
@@ -18,6 +18,7 @@ test: build
 	cargo test --doc --all
 
 .PHONY: serve-tls
+serve-tls: ${CERT_NAME}.crt.pem
 serve-tls:
 	cargo run ${SERVER_FEATURES} --bin ${SERVER_BIN} -- --directory ${HOME}/.bindle/bindles --address ${BINDLE_IFACE} ${TLS_OPTS}
 
@@ -42,6 +43,5 @@ build-server:
 build-client:
 	cargo build ${CLIENT_FEATURES} --bin ${CLIENT_BIN}
 
-.PHONY: gen-cert
-gen-cert:
+${CERT_NAME}.crt.pem:
 	openssl req -newkey rsa:2048 -nodes -keyout ${CERT_NAME}.key.pem -x509 -days 365 -out ${CERT_NAME}.crt.pem 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ BINDLE_ID ?= enterprise.com/warpcore/1.0.0
 BINDLE_IFACE ?= 127.0.0.1:8080
 MIME ?= "application/toml"
 CERT_NAME ?= ssl-example
-TLS_OPTS ?= --tls-cert ${CERT_NAME}.crt.pem --tls-key ${CERT_NAME}.key.pem
+TLS_OPTS ?= --tls-cert $(CERT_NAME).crt.pem --tls-key $(CERT_NAME).key.pem
 
-export RUST_LOG=error,warp=info,bindle=${BINDLE_LOG_LEVEL}
+export RUST_LOG=error,warp=info,bindle=$(BINDLE_LOG_LEVEL)
 
 .PHONY: test
 test: build
@@ -18,18 +18,22 @@ test: build
 	cargo test --doc --all
 
 .PHONY: serve-tls
-serve-tls: ${CERT_NAME}.crt.pem
-serve-tls:
-	cargo run ${SERVER_FEATURES} --bin ${SERVER_BIN} -- --directory ${HOME}/.bindle/bindles --address ${BINDLE_IFACE} ${TLS_OPTS}
+serve-tls: $(CERT_NAME).crt.pem
+serve-tls: _run
+	
 
 .PHONY: serve
 serve: TLS_OPTS =
-serve: serve-tls
+serve: _run
+
+.PHONY: _run
+_run:
+	cargo run $(SERVER_FEATURES) --bin $(SERVER_BIN) -- --directory $(HOME)/.bindle/bindles --address $(BINDLE_IFACE) $(TLS_OPTS)
 
 # Sort of a wacky hack if you want to do `$(make client) --help`
 .PHONY: client
 client:
-	@echo cargo run ${CLIENT_FEATURES} --bin ${CLIENT_BIN} -- 
+	@echo cargo run $(CLIENT_FEATURES) --bin $(CLIENT_BIN) -- 
 
 .PHONY: build
 build: build-server
@@ -37,11 +41,11 @@ build: build-client
 
 .PHONY: build-server
 build-server:
-	cargo build ${SERVER_FEATURES} --bin ${SERVER_BIN}
+	cargo build $(SERVER_FEATURES) --bin $(SERVER_BIN)
 
 .PHONY: build-client
 build-client:
-	cargo build ${CLIENT_FEATURES} --bin ${CLIENT_BIN}
+	cargo build $(CLIENT_FEATURES) --bin $(CLIENT_BIN)
 
-${CERT_NAME}.crt.pem:
-	openssl req -newkey rsa:2048 -nodes -keyout ${CERT_NAME}.key.pem -x509 -days 365 -out ${CERT_NAME}.crt.pem 
+$(CERT_NAME).crt.pem:
+	openssl req -newkey rsa:2048 -nodes -keyout $(CERT_NAME).key.pem -x509 -days 365 -out $(CERT_NAME).crt.pem

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ For both client and server, the `--help` flag will print out documentation.
 To start the compiled server, simply run `target/debug/bindle-server`. If you would like
 to see the available options, use the `--help` command.
 
-If you would like to run the server with `cargo run` (useful when debugging), use `make serve`.
+If you would like to run the server with `cargo run` (useful when debugging), use `make serve` or `make serve-tls`.
+
+You can generate self-signed testing SSL certificates with `make gen-cert`.
 
 #### Supplying a Configuration File
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ To start the compiled server, simply run `target/debug/bindle-server`. If you wo
 to see the available options, use the `--help` command.
 
 If you would like to run the server with `cargo run` (useful when debugging), use `make serve` or `make serve-tls`.
-
-You can generate self-signed testing SSL certificates with `make gen-cert`.
+(The first time you run `make serve-tls`, it will prompt you to create a testing TLS cert.)
 
 #### Supplying a Configuration File
 

--- a/bin/server.rs
+++ b/bin/server.rs
@@ -40,8 +40,8 @@ struct Opts {
     #[clap(
         name = "cert_path",
         short = 'c',
-        long = "cert-path",
-        env = "BINDLE_CERT_PATH",
+        long = "tls-cert",
+        env = "BINDLE_TLS_CERT",
         requires = "key_path",
         about = "the path to the TLS certificate to use. If set, --key-path must be set as well. If not set, the server will use HTTP"
     )]
@@ -49,8 +49,8 @@ struct Opts {
     #[clap(
         name = "key_path",
         short = 'k',
-        long = "key-path",
-        env = "BINDLE_KEY_PATH",
+        long = "tls-key",
+        env = "BINDLE_TLS_KEY",
         requires = "cert_path",
         about = "the path to the TLS certificate key to use. If set, --cert-path must be set as well. If not set, the server will use HTTP"
     )]
@@ -65,7 +65,7 @@ struct Opts {
         name = "keyring",
         short = 'r',
         long = "keyring",
-        about = "the path to the keyring file"
+        about = "the path to the public keyring file used for verifying signatures"
     )]
     keyring_file: Option<PathBuf>,
 
@@ -73,7 +73,7 @@ struct Opts {
         name = "signing_keys",
         long = "signing-keys",
         env = "BINDLE_SIGNING_KEYS",
-        about = "location of the TOML file that holds the signing keys"
+        about = "location of the TOML file that holds the signing keys used for creating signatures"
     )]
     signing_file: Option<PathBuf>,
 }


### PR DESCRIPTION
This streamlines the TLS configuration and matches it to a similar PR for Wagi.

- `make serve-tls` runs the server with TLS
- `make gen-cert` generates a testing TLS certificate
- The CLI args and env vars are changed to match Wagi's
- Other CLI help text was cleaned up to clarify the difference between TLS keys and signing keys
- The docs are updated

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>