### PR TITLE
feat(server): Adds configurable verification strategy

### DIFF
--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -53,6 +53,7 @@ pub mod v1 {
     pub async fn create_invoice<P: Provider, S: SecretKeyStorage>(
         store: P,
         secret_store: S,
+        strategy: VerificationStrategy,
         mut inv: crate::Invoice,
         accept_header: Option<String>,
     ) -> Result<impl warp::Reply, Infallible> {
@@ -63,8 +64,6 @@ pub mod v1 {
         // Then I need to validate the invoice against the public keys, sign the invoice
         // with my private key, and THEN go on to store.create_invoice()
 
-        // FIXME: Allow other strategies
-        let strategy = VerificationStrategy::default();
         let role = SignatureRole::Host;
         let sk = match secret_store.get_first_matching(&role) {
             None => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -28,7 +28,7 @@ pub struct TlsConfig {
 /// Returns a future that runs a server until it receives a SIGINT to stop. If optional TLS
 /// configuration is given, the server will be configured to use TLS. Otherwise it will use plain
 /// HTTP
-// TODO: Change this to a builder instead as this is too many arguments
+#[allow(clippy::too_many_arguments)]
 pub async fn server<P, I, Authn, Authz, S>(
     store: P,
     index: I,


### PR DESCRIPTION
You are now able to specify the verification strategy with a command line
flag or an item in the config file. This ended up being a bit more involved
than we initially thought due to the need to implement a custom deserialize
for the strategy

Closes #143