### PR TITLE
added accessor methods for StandaloneRead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,26 @@ export RUST_LOG=error,warp=info,bindle=$(BINDLE_LOG_LEVEL)
 
 .PHONY: test
 test: build
+test: test-fmt
+test: test-e2e
+test: test-docs
+
+.PHONY: test-fmt
+test-fmt:
 	cargo fmt --all -- --check
-	cargo test
+
+# Not called by `make test` because `test-e2e` does all the things already.
+.PHONY: test-unit
+test-unit:
+	cargo test --lib
+
+.PHONY: test-docs
+test-docs:
 	cargo test --doc --all
+
+.PHONY: test-e2e
+test-e2e:
+	cargo test --tests
 
 .PHONY: serve-tls
 serve-tls: $(CERT_NAME).crt.pem

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -35,6 +35,8 @@ use tracing::info;
 use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::BINDLE_VERSION_1;
+
 /// Alias for feature map in an Invoice's parcel
 pub type FeatureMap = BTreeMap<String, BTreeMap<String, String>>;
 
@@ -63,6 +65,22 @@ pub struct Invoice {
 }
 
 impl Invoice {
+    /// Create a new Invoice with a bindle specification.
+    ///
+    /// The returned bindle will have no parcels, annotations, signatures, or groups.
+    pub fn new(spec: BindleSpec) -> Self {
+        Invoice {
+            bindle_version: BINDLE_VERSION_1.to_owned(),
+            bindle: spec,
+            parcel: None,
+            yanked: None,
+            yanked_signature: None,
+            annotations: None,
+            signature: None,
+            group: None,
+        }
+    }
+
     /// produce a slash-delimited "invoice name"
     ///
     /// For example, an invoice with the bindle name "hello" and the bindle version

--- a/src/provider/file/mod.rs
+++ b/src/provider/file/mod.rs
@@ -31,9 +31,9 @@ use crate::Id;
 /// The folder name for the invoices directory
 const INVOICE_DIRECTORY: &str = "invoices";
 /// The folder name for the parcels directory
-const PARCEL_DIRECTORY: &str = "parcels";
+pub const PARCEL_DIRECTORY: &str = "parcels";
 const INVOICE_TOML: &str = "invoice.toml";
-const PARCEL_DAT: &str = "parcel.dat";
+pub const PARCEL_DAT: &str = "parcel.dat";
 const CACHE_SIZE: usize = 50;
 const PART_EXTENSION: &str = "part";
 


### PR DESCRIPTION
When pairing with @adamreese on https://github.com/deislabs/wagi/issues/79, I noticed that we had some missing features on `StandaloneRead`. This adds accessors to the invoice and parcels so that client users do not have to know anything about the file structure of a standalone bindle.

Also refactored the `Makefile` because I am impatient and want to run tests faster.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>