### PR TITLE
feat(proxy): Adds support for signing and verifying as a proxy

### DIFF
--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -28,7 +28,7 @@ use opts::*;
 #[tokio::main]
 async fn main() {
     // Trap and format error messages using the proper value
-    if let Err(e) = run().await.map_err(|e| anyhow::Error::new(e)) {
+    if let Err(e) = run().await.map_err(anyhow::Error::new) {
         eprintln!("{}", e);
         for (i, cause) in e.chain().enumerate() {
             // Skip the first message because it is printed above.
@@ -63,8 +63,7 @@ async fn run() -> std::result::Result<(), ClientError> {
             .unwrap_or_else(|_| KeyRing::default()),
     )
     .await;
-    let proxy = bindle::proxy::Proxy::new(bindle_client.clone());
-    let cache = DumbCache::new(proxy, local);
+    let cache = DumbCache::new(bindle_client.clone(), local);
 
     match opts.subcmd {
         SubCommand::Info(info_opts) => {

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -7,6 +7,7 @@ use reqwest::StatusCode;
 use tokio_stream::{Stream, StreamExt};
 
 use crate::provider::{Provider, ProviderError, Result};
+use crate::signature::KeyRing;
 use crate::Id;
 use crate::{
     client::{Client, ClientError},
@@ -14,36 +15,42 @@ use crate::{
     SecretKeyEntry, VerificationStrategy,
 };
 
+/// A proxy implementation that forwards requests to an upstream server as configured by a
+/// [`Client`](crate::client::Client). The proxy implementation will verify and sign invoice create
+/// operations and sign any fetched invoices
 #[derive(Clone)]
 pub struct Proxy {
     client: Client,
+    keyring: KeyRing,
+    secret_key: SecretKeyEntry,
 }
 
 impl Proxy {
-    pub fn new(client: Client) -> Self {
-        Proxy { client }
+    /// Returns a new proxy configured to connect to an upstream using the given client and verify
+    /// and sign using the given secret key and keyring
+    pub fn new(client: Client, secret_key: SecretKeyEntry, keyring: KeyRing) -> Self {
+        Proxy {
+            client,
+            keyring,
+            secret_key,
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl Provider for Proxy {
+    /// Creates the invoice on the upstream server, signing the invoice as a proxy. The role and
+    /// secret key parameters do not matter here
     async fn create_invoice(
         &self,
         inv: &mut crate::Invoice,
         _role: SignatureRole,
-        secret_key: &SecretKeyEntry,
-        _strategy: VerificationStrategy,
+        _secret_key: &SecretKeyEntry,
+        strategy: VerificationStrategy,
     ) -> Result<Vec<crate::Label>> {
-        // TODO: When we add proxy support as part of #141, we need to also add
-        // proxy verification here. We'll need to get the keyring and then do
-        // the verification using the official keyring. But we might need to
-        // add logic to ensure that the upstream proxy is remote, because if it is
-        // local we don't need to verify here.
-        // let keyring = KeyRing::default();
-        // strategy.verify(inv, &keyring)?;
+        strategy.verify(inv, &self.keyring)?;
 
-        let mut inv2 = inv.to_owned();
-        self.sign_invoice(&mut inv2, SignatureRole::Proxy, secret_key)?;
+        self.sign_invoice(inv, SignatureRole::Proxy, &self.secret_key)?;
 
         let res = self.client.create_invoice(inv.to_owned()).await?;
         Ok(res.missing.unwrap_or_default())
@@ -56,10 +63,9 @@ impl Provider for Proxy {
     {
         // Parse the ID now because the error type constraint doesn't match that of the client
         let parsed_id = id.try_into().map_err(|e| e.into())?;
-        self.client
-            .get_yanked_invoice(parsed_id)
-            .await
-            .map_err(|e| e.into())
+        let mut inv = self.client.get_yanked_invoice(parsed_id).await?;
+        self.sign_invoice(&mut inv, SignatureRole::Proxy, &self.secret_key)?;
+        Ok(inv)
     }
 
     async fn yank_invoice<I>(&self, id: I) -> Result<()>

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,0 +1,90 @@
+mod test_util;
+
+use std::convert::TryInto;
+
+use test_util::TestController;
+
+use bindle::provider::Provider;
+use bindle::proxy::Proxy;
+use bindle::signature::{KeyRing, SecretKeyEntry, SignatureRole};
+use bindle::testing;
+use bindle::VerificationStrategy;
+
+#[tokio::test]
+async fn test_proxy_get_signing() {
+    let controller = TestController::new().await;
+
+    // Create an initial invoice in the server
+    let scaffold = testing::Scaffold::load("valid_v1").await;
+    let id = scaffold.invoice.bindle.id.clone();
+    controller
+        .client
+        .create_invoice(scaffold.invoice)
+        .await
+        .expect("unable to create invoice");
+
+    let key_proxy = SecretKeyEntry::new("Test Proxy".to_owned(), vec![SignatureRole::Proxy]);
+    let pubkey = key_proxy.clone().try_into().expect("convert to pubkey");
+
+    // Setup the proxy
+    let proxy = Proxy::new(controller.client.clone(), key_proxy, KeyRing::default());
+
+    let inv = proxy
+        .get_yanked_invoice(id)
+        .await
+        .expect("Should be able to fetch invoice");
+
+    // Now verify that the invoice was signed by the proxy
+    let keyring = KeyRing::new(vec![pubkey]);
+
+    VerificationStrategy::MultipleAttestation(vec![SignatureRole::Proxy])
+        .verify(&inv, &keyring)
+        .expect("Invoice should be signed by the proxy")
+}
+
+// TODO: Uncomment this test to sign as a creator and check the validation once
+// https://github.com/deislabs/bindle/issues/167 is done.
+// #[tokio::test]
+// async fn test_proxy_create_verification_and_signing() {
+//     let controller = TestController::new().await;
+
+//     // Create an initial invoice in the server
+//     let scaffold = testing::Scaffold::load("valid_v1").await;
+//     let mut inv = scaffold.invoice.clone();
+
+//     let key_creator = SecretKeyEntry::new("Test Creator".to_owned(), vec![SignatureRole::Creator]);
+//     let key_proxy = SecretKeyEntry::new("Test Proxy".to_owned(), vec![SignatureRole::Proxy]);
+//     let keyring_keys = vec![
+//         key_creator.clone().try_into().expect("convert to pubkey"),
+//         key_proxy.clone().try_into().expect("convert to pubkey"),
+//     ];
+
+//     let keyring = KeyRing::new(keyring_keys);
+
+//     // Setup the proxy
+//     let proxy = Proxy::new(
+//         controller.client.clone(),
+//         key_proxy.clone(),
+//         keyring.clone(),
+//     );
+
+//     // Add another signature to make sure that the proxy can validate, but don't add creator because
+//     // the server doesn't have the public key available
+
+//     inv.sign(SignatureRole::Creator, &key_host).unwrap();
+
+//     // The role and secret key don't matter here
+//     proxy
+//         .create_invoice(
+//             &mut inv,
+//             SignatureRole::Proxy,
+//             &key_proxy,
+//             VerificationStrategy::CreativeIntegrity,
+//         )
+//         .await
+//         .expect("Should be able to create invoice");
+
+//     VerificationStrategy::MultipleAttestation(vec![SignatureRole::Proxy, SignatureRole::Creator])
+//         .verify(&inv, &keyring)
+//         .expect("Invoice should be signed by the proxy and creator keys");
+// }


### PR DESCRIPTION
As part of this, I realized that `Proxy` isn't the best thing to be using
for the client because it isn't truly a Proxy as it is acting as a provider
wrapper. This meant that we'd have a bunch of verification and signing code
you could turn off when using the proxy. Instead of doing that I just
did a `Provider` implementation for `Client`. This is a little less DRY, but
better separation of concerns and a cleaner API for `Proxy`

Closes #141