### PR TITLE
fix(*): Marks `Signed` trait as `Sealed`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindle"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bindle"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     "Matt Butcher <matt.butcher@microsoft.com>",
     "Taylor Thomas <taylor.thomas@microsoft.com>"

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ on Linux, MacOS, and Windows (in PowerShell):
 
 1. Download your desired version from [the releases
    page](https://github.com/deislabs/bindles/releases)
-1. Unpack it (`tar -xzf bindle-v0.4.0-linux-amd64.tar.gz`)
+1. Unpack it (`tar -xzf bindle-v0.4.1-linux-amd64.tar.gz`)
 1. Move the bindle and bindle CLIs to their desired
    destinations somewhere in your `$PATH` (e.g. `mv bindle bindle-server /usr/local/bin/` on Unix-like
    systems or `mv *.exe C:\Windows\system32\` on Windows)
@@ -38,7 +38,7 @@ find Bindle, check to make sure that your `$PATH` environment variable is set co
 #### Validating
 
 If you'd like to validate the download, checksums can be downloaded from
-https://bindle.blob.core.windows.net/releases/checksums-v0.4.0.txt
+https://bindle.blob.core.windows.net/releases/checksums-v0.4.1.txt
 
 ### From Canary Builds
 

--- a/docs/crate-readme.md
+++ b/docs/crate-readme.md
@@ -7,7 +7,7 @@ Bindle is an aggregate object storage system used for storing aggregate applicat
 Add the following to your `Cargo.toml` dependencies:
 
 ```toml
-bindle = "0.1"
+bindle = "0.4"
 ```
 
 ### Features

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -49,7 +49,7 @@ pub type AnnotationMap = BTreeMap<String, String>;
 
 /// A sealed trait used to mark that an invoice has been signed. This trait cannot be implemented by
 /// consumers of the bindle crate
-pub trait Signed {
+pub trait Signed: sealed::Sealed {
     /// Consumes the object, returning the signed invoice
     fn signed(self) -> Invoice;
 }


### PR DESCRIPTION
Somehow we missed this in the review so technically the trait was wide
open. This seals the trait and bumps the version in one go and then I'll
yank 0.4.0