### PR TITLE
Make client use same env var as server

### DIFF
--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -21,7 +21,7 @@ pub struct Opts {
     #[clap(
         short = 'd',
         long = "bindle-dir",
-        env = "BINDLE_DIR",
+        env = "BINDLE_DIRECTORY",
         about = "The directory where bindles are stored/cached, defaults to $XDG_CACHE_HOME"
     )]
     pub bindle_dir: Option<PathBuf>,


### PR DESCRIPTION
Change BINDLE_DIR to BINDLE_DIRECTORY in the client options to match the server options.

Closes #181

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>