### PR TITLE
fix(tests): Attempts to fix macos flake

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,6 +6,7 @@ use bindle::client::Client;
 use bindle::testing;
 
 const ENV_BINDLE_URL: &str = "BINDLE_URL";
+const BINARY_NAME: &str = "bindle-server";
 
 // Inserts data into the test server for fetching
 async fn setup_data(client: &Client) {
@@ -35,7 +36,7 @@ async fn setup_data(client: &Client) {
 
 #[tokio::test]
 async fn test_push() {
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
     let root = std::env::var("CARGO_MANIFEST_DIR").expect("Unable to get project directory");
     let path = std::path::PathBuf::from(root).join("test/data/standalone");
     // TODO: Figure out how to dedup these outputs. I tried doing something but `args` returns an `&mut` which complicates things
@@ -60,7 +61,7 @@ async fn test_push() {
 
 #[tokio::test]
 async fn test_push_invoice_and_file() {
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
     let root = std::env::var("CARGO_MANIFEST_DIR").expect("Unable to get project directory");
     let base = std::path::PathBuf::from(root).join("tests/scaffolds/valid_v1");
     let output = std::process::Command::new("cargo")
@@ -101,7 +102,7 @@ async fn test_push_invoice_and_file() {
 
 #[tokio::test]
 async fn test_get() {
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
     setup_data(&controller.client).await;
     let cachedir = tempfile::tempdir().expect("unable to set up tempdir");
     let output = std::process::Command::new("cargo")
@@ -180,7 +181,7 @@ async fn test_get() {
 
 #[tokio::test]
 async fn test_get_invoice() {
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
     setup_data(&controller.client).await;
 
     let tempdir = tempfile::tempdir().expect("Unable to set up tempdir");
@@ -262,7 +263,7 @@ async fn test_create_key_and_sign_invoice() {
 
 #[tokio::test]
 async fn test_get_parcel() {
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
     setup_data(&controller.client).await;
 
     let tempdir = tempfile::tempdir().expect("Unable to set up tempdir");
@@ -299,7 +300,7 @@ async fn test_get_parcel() {
 
 #[tokio::test]
 async fn test_yank() {
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
     setup_data(&controller.client).await;
 
     let output = std::process::Command::new("cargo")

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -10,11 +10,13 @@ use bindle::testing;
 
 use tokio_stream::StreamExt;
 
+const BINARY_NAME: &str = "bindle-server";
+
 #[tokio::test]
 async fn test_successful() {
     // This first creates some invoices/parcels and then tries fetching them to see that they work.
     // Once we confirm that works, we test yank
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
 
     let scaffold = testing::Scaffold::load("valid_v1").await;
 
@@ -74,7 +76,7 @@ async fn test_successful() {
 
 #[tokio::test]
 async fn test_streaming_successful() {
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
 
     // Use raw paths instead of scaffolds so we can test the stream
     let root = std::env::var("CARGO_MANIFEST_DIR").expect("Unable to get project directory");
@@ -133,7 +135,7 @@ async fn test_streaming_successful() {
 
 #[tokio::test]
 async fn test_already_created() {
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
 
     let scaffold = testing::Scaffold::load("valid_v2").await;
 
@@ -168,7 +170,7 @@ async fn test_already_created() {
 
 #[tokio::test]
 async fn test_missing() {
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
 
     // Create a bindle with missing invoices
     let scaffold = testing::Scaffold::load("lotsa_parcels").await;
@@ -214,7 +216,7 @@ async fn test_missing() {
 
 #[tokio::test]
 async fn test_charset() {
-    let controller = TestController::new().await;
+    let controller = TestController::new(BINARY_NAME).await;
 
     let scaffold = testing::RawScaffold::load("valid_v1").await;
 


### PR DESCRIPTION
I believe that the slowness of the GH runners was creating issues when using
`cargo run` to run the server binary - even after previously building it. This
changes things to run the built binary directly instead, avoid the overhead of
"rebuilding" it. It also makes things more generic so people consuming test
utils are not required to have a specific binary name