### PR TITLE
default http2_prior_knowledge to false

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -39,10 +39,6 @@ pub struct Client {
 /// Options for setting up a `Client`
 pub struct ClientOptions {
     /// Controls whether the client assumes HTTP/2 or attempts to negotiate it.
-    /// The default is to assume HTTP/2, bypassing the negotiation step, because
-    /// the Bindle server always offers HTTP/2. However, it can be useful to negotiate
-    /// if the server may be behind a proxy or tunnelling service. Set
-    /// `http2_prior_knowledge` to `false` to negotiate.
     pub http2_prior_knowledge: bool,
     /// Controls whether the client accepts invalid certificates. The default is
     /// to reject invalid certificates. It is sometimes necessary to set this
@@ -54,7 +50,7 @@ pub struct ClientOptions {
 impl Default for ClientOptions {
     fn default() -> Self {
         Self {
-            http2_prior_knowledge: true,
+            http2_prior_knowledge: false,
             danger_accept_invalid_certs: false,
         }
     }


### PR DESCRIPTION
fixes #202

Before:

```
><> bindle --server https://bindle.f1sh.ca:8080/v1 search
Error creating request

Error trace:
	1: error sending request for url (https://bindle.f1sh.ca:8080/v1/_q): http2 error: protocol error: frame with invalid size
	2: http2 error: protocol error: frame with invalid size
	3: protocol error: frame with invalid size
```

After:

```
><> bindle --server https://bindle.f1sh.ca:8080/v1 search
query = ""
strict = true
offset = 0
limit = 50
total = 0
more = false
yanked = false
invoices = []
```