### PR TITLE
exp(provider): Adds support for experimental embedded provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,10 +75,13 @@ dependencies = [
  "mime_guess",
  "rand 0.7.3",
  "reqwest",
+ "rstest",
  "semver",
  "serde",
+ "serde_cbor",
  "serde_json",
  "sha2",
+ "sled",
  "tempfile",
  "thiserror",
  "tokio",
@@ -217,6 +220,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +357,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +519,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
@@ -714,6 +774,15 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1205,6 +1274,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "041bb0202c14f6a158bbbf086afb03d0c6e975c2dec7d4912f8061ed44f290af"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1404,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1502,22 @@ name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+
+[[package]]
+name = "sled"
+version = "0.34.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d0132f3e393bcb7390c60bb45769498cf4550bcb7a21d7f95c02b69f6362cdc"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ maintenance = { status = "actively-developed" }
 default = ["server", "client", "caching", "test-tools"]
 server = ["warp"]
 client = ["reqwest", "mime_guess", "dirs"]
+embedded = ["sled", "serde_cbor"]
 caching = []
 test-tools = []
 cli = ["clap", "tracing-subscriber"]
@@ -66,6 +67,11 @@ base64 = "0.13"
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
 mime = "0.3"
+sled = {version = "0.34", optional = true}
+serde_cbor = {version = "0.11", optional = true}
+
+[dev-dependencies]
+rstest = "0.10"
 
 [[bin]]
 name = "bindle-server"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ maintenance = { status = "actively-developed" }
 default = ["server", "client", "caching", "test-tools"]
 server = ["warp"]
 client = ["reqwest", "mime_guess", "dirs"]
-embedded = ["sled", "serde_cbor"]
 caching = []
 test-tools = []
 cli = ["clap", "tracing-subscriber"]
@@ -67,8 +66,8 @@ base64 = "0.13"
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
 mime = "0.3"
-sled = {version = "0.34", optional = true}
-serde_cbor = {version = "0.11", optional = true}
+sled = "0.34"
+serde_cbor = "0.11"
 
 [dev-dependencies]
 rstest = "0.10"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASE_SERVER_FEATURES = --features cli
+SERVER_FEATURES = --features cli
 SERVER_BIN := bindle-server
 CLIENT_FEATURES ?= --features=cli
 CLIENT_BIN := bindle
@@ -8,6 +8,7 @@ BINDLE_IFACE ?= 127.0.0.1:8080
 MIME ?= "application/toml"
 CERT_NAME ?= ssl-example
 TLS_OPTS ?= --tls-cert $(CERT_NAME).crt.pem --tls-key $(CERT_NAME).key.pem
+EMBEDDED_FLAG ?= --use-embedded-db true
 
 export RUST_LOG=error,warp=info,bindle=$(BINDLE_LOG_LEVEL)
 
@@ -24,7 +25,7 @@ test-fmt:
 # Not called by `make test` because `test-e2e` does all the things already.
 .PHONY: test-unit
 test-unit:
-	cargo test --lib --features embedded
+	cargo test --lib
 
 .PHONY: test-docs
 test-docs:
@@ -32,33 +33,32 @@ test-docs:
 
 .PHONY: test-e2e
 test-e2e:
-	cargo test --tests --features embedded
+	cargo test --tests
 
 .PHONY: serve-tls
 serve-tls: $(CERT_NAME).crt.pem
+serve-tls: EMBEDDED_FLAG =
 serve-tls: _run
 
 .PHONY: serve
 serve: TLS_OPTS =
-serve: SERVER_FEATURES = $(BASE_SERVER_FEATURES)
+serve: EMBEDDED_FLAG =
 serve: BINDLE_DIRECTORY = $(HOME)/.bindle/bindles
 serve: _run
 
 .PHONY: serve-embedded
 serve-embedded: TLS_OPTS =
 serve-embedded: BINDLE_DIRECTORY = $(HOME)/.bindle/bindles-embedded
-serve-embedded: SERVER_FEATURES = $(BASE_SERVER_FEATURES),embedded
 serve-embedded: _run
 
 .PHONY: serve-embedded-tls
 serve-embedded-tls: $(CERT_NAME).crt.pem
 serve-embedded-tls: BINDLE_DIRECTORY = $(HOME)/.bindle/bindles-embedded
-serve-embedded-tls: SERVER_FEATURES = $(BASE_SERVER_FEATURES),embedded
 serve-embedded-tls: _run
 
 .PHONY: _run
 _run:
-	cargo run $(SERVER_FEATURES) --bin $(SERVER_BIN) -- --directory $(BINDLE_DIRECTORY) --address $(BINDLE_IFACE) $(TLS_OPTS)
+	cargo run $(SERVER_FEATURES) --bin $(SERVER_BIN) -- --directory $(BINDLE_DIRECTORY) --address $(BINDLE_IFACE) $(TLS_OPTS) $(EMBEDDED_FLAG)
 
 # Sort of a wacky hack if you want to do `$(make client) --help`
 .PHONY: client
@@ -70,13 +70,7 @@ build: build-server
 build: build-client
 
 .PHONY: build-server
-build-server: SERVER_FEATURES = $(BASE_SERVER_FEATURES)
 build-server:
-	cargo build $(SERVER_FEATURES) --bin $(SERVER_BIN)
-
-.PHONY: build-embedded-server
-build-embedded-server: SERVER_FEATURES = $(BASE_SERVER_FEATURES),embedded
-build-embedded-server:
 	cargo build $(SERVER_FEATURES) --bin $(SERVER_BIN)
 
 .PHONY: build-client

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SERVER_FEATURES ?= --all-features
+BASE_SERVER_FEATURES = --features cli
 SERVER_BIN := bindle-server
 CLIENT_FEATURES ?= --features=cli
 CLIENT_BIN := bindle
@@ -24,7 +24,7 @@ test-fmt:
 # Not called by `make test` because `test-e2e` does all the things already.
 .PHONY: test-unit
 test-unit:
-	cargo test --lib
+	cargo test --lib --features embedded
 
 .PHONY: test-docs
 test-docs:
@@ -32,20 +32,33 @@ test-docs:
 
 .PHONY: test-e2e
 test-e2e:
-	cargo test --tests
+	cargo test --tests --features embedded
 
 .PHONY: serve-tls
 serve-tls: $(CERT_NAME).crt.pem
 serve-tls: _run
-	
 
 .PHONY: serve
 serve: TLS_OPTS =
+serve: SERVER_FEATURES = $(BASE_SERVER_FEATURES)
+serve: BINDLE_DIRECTORY = $(HOME)/.bindle/bindles
 serve: _run
+
+.PHONY: serve-embedded
+serve-embedded: TLS_OPTS =
+serve-embedded: BINDLE_DIRECTORY = $(HOME)/.bindle/bindles-embedded
+serve-embedded: SERVER_FEATURES = $(BASE_SERVER_FEATURES),embedded
+serve-embedded: _run
+
+.PHONY: serve-embedded-tls
+serve-embedded-tls: $(CERT_NAME).crt.pem
+serve-embedded-tls: BINDLE_DIRECTORY = $(HOME)/.bindle/bindles-embedded
+serve-embedded-tls: SERVER_FEATURES = $(BASE_SERVER_FEATURES),embedded
+serve-embedded-tls: _run
 
 .PHONY: _run
 _run:
-	cargo run $(SERVER_FEATURES) --bin $(SERVER_BIN) -- --directory $(HOME)/.bindle/bindles --address $(BINDLE_IFACE) $(TLS_OPTS)
+	cargo run $(SERVER_FEATURES) --bin $(SERVER_BIN) -- --directory $(BINDLE_DIRECTORY) --address $(BINDLE_IFACE) $(TLS_OPTS)
 
 # Sort of a wacky hack if you want to do `$(make client) --help`
 .PHONY: client
@@ -57,7 +70,13 @@ build: build-server
 build: build-client
 
 .PHONY: build-server
+build-server: SERVER_FEATURES = $(BASE_SERVER_FEATURES)
 build-server:
+	cargo build $(SERVER_FEATURES) --bin $(SERVER_BIN)
+
+.PHONY: build-embedded-server
+build-embedded-server: SERVER_FEATURES = $(BASE_SERVER_FEATURES),embedded
+build-embedded-server:
 	cargo build $(SERVER_FEATURES) --bin $(SERVER_BIN)
 
 .PHONY: build-client

--- a/src/provider/embedded.rs
+++ b/src/provider/embedded.rs
@@ -1,0 +1,462 @@
+//! An embedded database backed `Provider` implementation.
+//!
+//! Currently, the underlying storage engine uses the [sled embedded
+//! database](https://github.com/spacejam/sled). This database provides caching support as well as
+//! atomic operations. Underneath the hood, we encode the data using the
+//! [CBOR](https://github.com/pyfisch/cbor) format for efficient serialization/deserialization from
+//! the database.
+//!
+//! This provider is currently experimental, with the goal of replacing the `FileProvider` as the
+//! default provider in the future. This provider is only available with the `embedded` feature
+//! enabled. Please note that the embedded data store and encoding format may change until this
+//! feature is stabilized
+
+use std::convert::TryInto;
+use std::path::Path;
+use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
+use sled::Error as SledError;
+use tokio::io::AsyncReadExt;
+use tokio::sync::Semaphore;
+use tokio_stream::{Stream, StreamExt};
+use tokio_util::codec::{BytesCodec, FramedRead};
+use tokio_util::io::StreamReader;
+use tracing::{debug, error, info, instrument, trace, warn};
+use tracing_futures::Instrument;
+
+use crate::provider::{Provider, ProviderError, Result};
+use crate::search::Search;
+use crate::verification::Verified;
+use crate::{Id, Signed};
+
+const INVOICE_DB_NAME: &str = "invoices";
+const PARCEL_DB_NAME: &str = "parcels";
+// TODO: This number should be equal to the number of threads configured for blocking. We could
+// expose this value in the constructor, but that feels too much like a low-level detail to expose
+// in the API. But I also can't find a way to fetch this configured value
+const BLOCKING_THREAD_COUNT: usize = 512;
+
+/// An embedded database backend for storing and retrieving bindles and parcles.
+///
+/// Given a storage directory, EmbeddedProvider brings its own storage layout for keeping track of
+/// Bindles.
+///
+/// An EmbeddedProvider needs a search engine implementation. When invoices are created or yanked,
+/// the index will be updated.
+pub struct EmbeddedProvider<T> {
+    invoices: sled::Tree,
+    parcels: sled::Tree,
+    index: T,
+    semaphore: Arc<Semaphore>,
+}
+
+impl<T: Clone> Clone for EmbeddedProvider<T> {
+    fn clone(&self) -> Self {
+        EmbeddedProvider {
+            invoices: self.invoices.clone(),
+            parcels: self.parcels.clone(),
+            index: self.index.clone(),
+            semaphore: self.semaphore.clone(),
+        }
+    }
+}
+
+impl<T: Search + Send + Sync> EmbeddedProvider<T> {
+    pub async fn new<P: AsRef<Path>>(storage_path: P, index: T) -> anyhow::Result<Self> {
+        debug!(storage_path = %storage_path.as_ref().display(), "Creating new embedded provider");
+        let sp = storage_path.as_ref().to_owned();
+        let db = tokio::task::spawn_blocking(|| sled::open(sp)).await??;
+        let owned = db.clone();
+        let invoices =
+            tokio::task::spawn_blocking(move || owned.open_tree(INVOICE_DB_NAME)).await??;
+        let parcels = tokio::task::spawn_blocking(move || db.open_tree(PARCEL_DB_NAME)).await??;
+        let emb = EmbeddedProvider {
+            invoices,
+            parcels,
+            index,
+            semaphore: Arc::new(Semaphore::new(BLOCKING_THREAD_COUNT)),
+        };
+        debug!("warming index");
+        if let Err(e) = emb.warm_index().await {
+            warn!(error = %e, "Error warming index");
+        }
+        Ok(emb)
+    }
+
+    /// This warms the index by loading all of the invoices currently in the DB
+    ///
+    /// Warming the index is something that the storage backend should do, though I am
+    /// not sure whether EVERY storage backend should do it. It is the responsibility of
+    /// storage because storage is the sole authority about what documents are actually
+    /// in the repository. So it needs to communicate (on startup) what documents it knows
+    /// about. The storage engine merely needs to store any non-duplicates. So we can
+    /// safely insert, but ignore errors that come back because of duplicate entries.
+    #[instrument(level = "trace", skip(self))]
+    async fn warm_index(&self) -> anyhow::Result<()> {
+        // Read all invoices
+        // info!(path = %self.root.display(), "Beginning index warm");
+        // let mut total_indexed: u64 = 0;
+        // // Check if the invoice directory exists. If it doesn't, this is likely the first time and
+        // // we should just return
+        // let invoice_path = self.invoice_path("");
+        // match tokio::fs::metadata(&invoice_path).await {
+        //     Ok(_) => (),
+        //     Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => return Ok(()),
+        //     Err(e) => return Err(e.into()),
+        // };
+        // let mut readdir = tokio::fs::read_dir(invoice_path).await?;
+        // while let Some(e) = readdir.next_entry().await? {
+        //     let p = e.path();
+        //     let sha = match p.file_name().map(|f| f.to_string_lossy()) {
+        //         Some(sha_opt) => sha_opt,
+        //         None => continue,
+        //     };
+        //     // Load invoice
+        //     let inv_path = self.invoice_toml_path(&sha);
+        //     info!(path = %inv_path.display(), "Loading invoice into search index");
+        //     // Open file
+        //     let inv_toml = tokio::fs::read(inv_path).await?;
+
+        //     // Parse
+        //     let invoice: crate::Invoice = toml::from_slice(&inv_toml)?;
+        //     let digest = invoice.canonical_name();
+        //     if sha != digest {
+        //         anyhow::bail!(
+        //             "SHA {} did not match computed digest {}. Delete this record.",
+        //             sha,
+        //             digest
+        //         );
+        //     }
+
+        //     if let Err(e) = self.index.index(&invoice).await {
+        //         error!(invoice_id = %invoice.bindle.id, error = %e, "Error indexing invoice");
+        //     }
+        //     total_indexed += 1;
+        // }
+        // debug!(total_indexed, "Warmed index");
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: crate::search::Search + Send + Sync> Provider for EmbeddedProvider<T> {
+    #[instrument(level = "trace", skip(self, invoice), fields(invoice_id = tracing::field::Empty))]
+    async fn create_invoice<I>(&self, invoice: I) -> Result<(crate::Invoice, Vec<crate::Label>)>
+    where
+        I: Signed + Verified + Send + Sync,
+    {
+        let inv = invoice.signed();
+        tracing::span::Span::current()
+            .record("invoice_id", &tracing::field::display(&inv.bindle.id));
+        // It is illegal to create a yanked invoice.
+        if inv.yanked.unwrap_or(false) {
+            debug!(id = %inv.bindle.id, "Invoice being created is set to yanked");
+            return Err(ProviderError::CreateYanked);
+        }
+
+        let invoice_id = inv.canonical_name();
+
+        let invoices = self.invoices.clone();
+
+        let serialized = serde_cbor::to_vec(&inv)?;
+
+        debug!("Inserting invoice into database");
+        let res = spawn_lock(self.semaphore.clone(), move || {
+            invoices.compare_and_swap(&invoice_id, None as Option<&[u8]>, Some(serialized))
+        })
+        .await?;
+
+        match res {
+            Ok(Ok(())) => (),
+            Err(e) => return Err(map_sled_error(e)),
+            // We'll only get a compare and swap error if it already exists
+            Ok(Err(_)) => return Err(ProviderError::Exists),
+        }
+
+        // Attempt to update the index. Right now, we log an error if the index update
+        // fails.
+        if let Err(e) = self.index.index(&inv).await {
+            error!(error = %e, "Error indexing new invoice");
+        }
+
+        // if there are no parcels, bail early
+        if inv.parcel.is_none() {
+            return Ok((inv, Vec::with_capacity(0)));
+        }
+
+        trace!("Checking for missing parcels listed in newly created invoice");
+        let s = self.semaphore.clone();
+        let parcels = self.parcels.clone();
+        // Loop through the boxes and see what exists
+        let missing = inv
+            .parcel
+            // Need to clone so we can move into the spawn_lock
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|k| (s.clone(), parcels.clone(), k.label))
+            .map(|(s, parcels, label)| async move {
+                // Check if the parcel exists in the database
+                let sha = label.sha256.to_owned();
+                let found = spawn_lock(s, move || parcels.contains_key(&sha).unwrap_or(false))
+                    .await
+                    .unwrap_or(false);
+                if found {
+                    None
+                } else {
+                    Some(label)
+                }
+            });
+
+        let labels = futures::future::join_all(missing)
+            .instrument(tracing::trace_span!("lookup_missing"))
+            .await
+            .into_iter()
+            .flatten()
+            .collect();
+        Ok((inv, labels))
+    }
+
+    #[instrument(level = "trace", skip(self, id), fields(id))]
+    async fn get_yanked_invoice<I>(&self, id: I) -> Result<crate::Invoice>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<ProviderError>,
+    {
+        let parsed_id: Id = id.try_into().map_err(|e| e.into())?;
+        tracing::Span::current().record("id", &tracing::field::display(&parsed_id));
+
+        // NOTE: sled has its own caching, so we don't need to worry about manually implementing
+        // here
+        debug!("Getting invoice from database");
+
+        let invoice_id = parsed_id.sha();
+        let invoices = self.invoices.clone();
+        let data = match spawn_lock(self.semaphore.clone(), move || invoices.get(&invoice_id))
+            .await?
+            .map_err(map_sled_error)?
+        {
+            Some(d) => d,
+            None => return Err(ProviderError::NotFound),
+        };
+
+        // Parse
+        trace!("Parsing invoice from raw data");
+        let invoice: crate::Invoice = serde_cbor::from_slice(data.as_ref())?;
+
+        // Return object
+        Ok(invoice)
+    }
+
+    #[instrument(level = "trace", skip(self, id), fields(id))]
+    async fn yank_invoice<I>(&self, id: I) -> Result<()>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<ProviderError>,
+    {
+        let parsed_id = id.try_into().map_err(|e| e.into())?;
+        tracing::Span::current().record("id", &tracing::field::display(&parsed_id));
+        trace!("Fetching invoice from storage");
+        let mut inv = self.get_yanked_invoice(&parsed_id).await?;
+        inv.yanked = Some(true);
+
+        debug!("Yanking invoice");
+
+        // NOTE: Using the update_and_fetch method would result in a double deserialization step so
+        // we can re-index. There _is_ a small possibility that someone could fetch the current
+        // value from the DB right before we mutate, but the consequences of this are likely small
+        // or non-existent, so we aren't worrying about wrapping in a transaction
+
+        // Attempt to update the index. Right now, we log an error if the index update
+        // fails.
+        trace!("Indexing yanked invoice");
+        if let Err(e) = self.index.index(&inv).await {
+            error!(error = %e, "Error indexing yanked invoice");
+        }
+
+        // Encode the invoice into a TOML object
+        trace!("Encoding invoice");
+        let serialized = serde_cbor::to_vec(&inv)?;
+        let invoice_id = inv.canonical_name();
+        let invoices = self.invoices.clone();
+        debug!("Writing yanked invoice to database");
+        spawn_lock(self.semaphore.clone(), move || {
+            invoices.insert(&invoice_id, serialized)
+        })
+        .await?
+        .map_err(map_sled_error)?;
+
+        Ok(())
+    }
+
+    #[instrument(level = "trace", skip(self, bindle_id, data), fields(id))]
+    async fn create_parcel<I, R, B>(&self, bindle_id: I, parcel_id: &str, data: R) -> Result<()>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<ProviderError>,
+        R: Stream<Item = std::io::Result<B>> + Unpin + Send + Sync + 'static,
+        B: bytes::Buf + Send,
+    {
+        debug!("Validating bindle -> parcel relationship");
+        let parsed_id = bindle_id.try_into().map_err(|e| e.into())?;
+        tracing::Span::current().record("id", &tracing::field::display(&parsed_id));
+        let label = self.validate_parcel(parsed_id, parcel_id).await?;
+
+        debug!("Reading data from stream");
+
+        // Read the data into memory (it is going to start there anyway in the database before
+        // getting flushed to disk)
+        let mut parcel_data: Vec<u8> = Vec::with_capacity(label.size as usize);
+        StreamReader::new(
+            data.map(|res| res.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))),
+        )
+        .read_to_end(&mut parcel_data)
+        .await?;
+
+        debug!("Validating size");
+        if parcel_data.len() as u64 != label.size {
+            info!(
+                expected = label.size,
+                read_bytes = parcel_data.len(),
+                "Attempted to insert parcel with incorrect size"
+            );
+            return Err(ProviderError::SizeMismatch);
+        }
+
+        debug!("Validating sha");
+        let calculated = format!("{:x}", Sha256::digest(&parcel_data));
+        if label.sha256 != calculated {
+            info!(expected_sha = %label.sha256, %calculated, "Mismatched SHA when creating parcel");
+            return Err(ProviderError::DigestMismatch);
+        }
+
+        debug!("Inserting parcel into database");
+        let parcels = self.parcels.clone();
+        let pid = parcel_id.to_owned();
+        let res = spawn_lock(self.semaphore.clone(), move || {
+            parcels.compare_and_swap(&pid, None as Option<&[u8]>, Some(parcel_data))
+        })
+        .await?;
+
+        match res {
+            Ok(Ok(())) => Ok(()),
+            Err(e) => Err(map_sled_error(e)),
+            // This error is only possible if the parcel already exists
+            Ok(Err(_)) => Err(ProviderError::Exists),
+        }
+    }
+
+    #[instrument(level = "trace", skip(self, bindle_id), fields(id))]
+    async fn get_parcel<I>(
+        &self,
+        bindle_id: I,
+        parcel_id: &str,
+    ) -> Result<Box<dyn Stream<Item = Result<bytes::Bytes>> + Unpin + Send + Sync>>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<ProviderError>,
+    {
+        debug!("Validating bindle -> parcel relationship");
+        let parsed_id = bindle_id.try_into().map_err(|e| e.into())?;
+        tracing::Span::current().record("id", &tracing::field::display(&parsed_id));
+        self.validate_parcel(parsed_id, parcel_id).await?;
+
+        debug!("Getting parcel from storage");
+        let parcels = self.parcels.clone();
+        let pid = parcel_id.to_owned();
+        let data = match spawn_lock(self.semaphore.clone(), move || parcels.get(&pid))
+            .await?
+            .map_err(map_sled_error)?
+        {
+            // Wrap the data in a cursor so it implements AsyncRead and can be streamed
+            Some(d) => std::io::Cursor::new(d),
+            None => return Err(ProviderError::NotFound),
+        };
+
+        Ok::<Box<dyn Stream<Item = Result<bytes::Bytes>> + Unpin + Send + Sync>, _>(Box::new(
+            FramedRead::new(data, BytesCodec::new())
+                .map(|res| res.map_err(map_io_error).map(|b| b.freeze())),
+        ))
+    }
+
+    #[instrument(level = "trace", skip(self, bindle_id), fields(id))]
+    async fn parcel_exists<I>(&self, bindle_id: I, parcel_id: &str) -> Result<bool>
+    where
+        I: TryInto<Id> + Send,
+        I::Error: Into<ProviderError>,
+    {
+        debug!("Validating bindle -> parcel relationship");
+        let parsed_id = bindle_id.try_into().map_err(|e| e.into())?;
+        tracing::Span::current().record("id", &tracing::field::display(&parsed_id));
+        self.validate_parcel(parsed_id, parcel_id).await?;
+
+        debug!("Checking if parcel exists in storage");
+        let pid = parcel_id.to_owned();
+        let parcels = self.parcels.clone();
+        spawn_lock(self.semaphore.clone(), move || parcels.contains_key(&pid))
+            .await?
+            .map_err(map_sled_error)
+    }
+}
+
+fn map_io_error(e: std::io::Error) -> ProviderError {
+    if matches!(e.kind(), std::io::ErrorKind::NotFound) {
+        return ProviderError::NotFound;
+    }
+    ProviderError::from(e)
+}
+
+fn map_sled_error(e: SledError) -> ProviderError {
+    match &e {
+        // This is a panicable error because if the collection is somehow gone, we can't keep
+        // continuing
+        SledError::CollectionNotFound(e) => panic!(
+            "The collection {} was not found, something is wrong with the database",
+            String::from_utf8_lossy(e)
+        ),
+        SledError::Io(i) => {
+            error!(error = ?e, "IO error occurred while accessingata store");
+            // Add some more decoration as to _where_ the IO error came from
+            ProviderError::Io(std::io::Error::new(
+                i.kind(),
+                format!("Error accessing local data store: {}", i),
+            ))
+        }
+        SledError::Unsupported(_) | SledError::ReportableBug(_) => {
+            error!(error = ?e, "Error while attempting to access embedded data store");
+            ProviderError::Other(String::from(
+                "Internal system error while performing data storage lookup",
+            ))
+        }
+        SledError::Corruption { at, bt } => {
+            // This is a panicable error as it means the data store is corrupted and we
+            // no longer have all our data
+            panic!(
+                "Detected database corruption at: {:?}, with backtrace of: {:?}",
+                at, bt
+            )
+        }
+    }
+}
+
+/// A helper function that wraps `spawn_blocking` with a semaphore permit acquisition
+async fn spawn_lock<F, R>(semaphore: Arc<Semaphore>, f: F) -> Result<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    // According to the docs, the only error that can occur here is if the semaphore is closed.
+    // In that case, we should panic as it should never close while the application is running
+    let _permit = semaphore
+        .acquire()
+        .await
+        .expect("Unable to synchronize threads...aborting");
+    trace!(
+        remaining_permits = semaphore.available_permits(),
+        "Successfully acquired spawn_blocking permit"
+    );
+    Ok(tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|_| ProviderError::Other("Internal error: unable to lock task".into()))?)
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -21,7 +21,6 @@
 //! will generally contain another Provider implementation or an HTTP client to talk to another
 //! server upstream
 
-#[cfg(feature = "embedded")]
 pub mod embedded;
 pub mod file;
 
@@ -206,7 +205,6 @@ impl From<std::convert::Infallible> for ProviderError {
     }
 }
 
-#[cfg(feature = "embedded")]
 // TODO(thomastaylor312): We should probably have a more generic form of
 // deserialization/serialization errors that aren't tied to TOML as backends can serialize how they
 // want. For now there is this workaround

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -103,15 +103,24 @@ mod test {
         SignatureRole, VerificationStrategy,
     };
     use crate::provider::Provider;
-    use crate::testing;
+    use crate::search::StrictEngine;
+    use crate::testing::{self, MockKeyStore};
 
+    use rstest::rstest;
     use testing::Scaffold;
     use tokio_util::codec::{BytesCodec, FramedRead};
 
+    #[rstest]
     #[tokio::test]
-    async fn test_successful_workflow() {
+    async fn test_successful_workflow<T>(
+        #[values(testing::setup(), testing::setup_embedded())]
+        #[future]
+        provider_setup: (T, StrictEngine, MockKeyStore),
+    ) where
+        T: Provider + Clone + Send + Sync + 'static,
+    {
         let bindles = testing::load_all_files().await;
-        let (store, index, ks) = testing::setup().await;
+        let (store, index, ks) = provider_setup.await;
 
         let api = super::routes::api(
             store,
@@ -272,9 +281,16 @@ mod test {
         );
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_yank() {
-        let (store, index, ks) = testing::setup().await;
+    async fn test_yank<T>(
+        #[values(testing::setup(), testing::setup_embedded())]
+        #[future]
+        provider_setup: (T, StrictEngine, MockKeyStore),
+    ) where
+        T: Provider + Clone + Send + Sync + 'static,
+    {
+        let (store, index, ks) = provider_setup.await;
 
         let api = super::routes::api(
             store.clone(),
@@ -339,12 +355,19 @@ mod test {
         toml::from_slice::<crate::Invoice>(res.body()).expect("should be valid invoice TOML");
     }
 
+    #[rstest]
     #[tokio::test]
     // This isn't meant to test all of the possible validation failures (that should be done in a unit
     // test for storage), just the main validation failures from the API
-    async fn test_invoice_validation() {
+    async fn test_invoice_validation<T>(
+        #[values(testing::setup(), testing::setup_embedded())]
+        #[future]
+        provider_setup: (T, StrictEngine, MockKeyStore),
+    ) where
+        T: Provider + Clone + Send + Sync + 'static,
+    {
         let bindles = testing::load_all_files().await;
-        let (store, index, ks) = testing::setup().await;
+        let (store, index, ks) = provider_setup.await;
 
         let api = super::routes::api(
             store.clone(),
@@ -383,11 +406,18 @@ mod test {
         );
     }
 
+    #[rstest]
     #[tokio::test]
     // This isn't meant to test all of the possible validation failures (that should be done in a unit
     // test for storage), just the main validation failures from the API
-    async fn test_parcel_validation() {
-        let (store, index, keystore) = testing::setup().await;
+    async fn test_parcel_validation<T>(
+        #[values(testing::setup(), testing::setup_embedded())]
+        #[future]
+        provider_setup: (T, StrictEngine, MockKeyStore),
+    ) where
+        T: Provider + Clone + Send + Sync + 'static,
+    {
+        let (store, index, keystore) = provider_setup.await;
 
         let api = super::routes::api(
             store.clone(),
@@ -473,12 +503,19 @@ mod test {
         );
     }
 
+    #[rstest]
     #[tokio::test]
     // Once again, this isn't meant to exercise all of the query functionality, just that the API
     // functions properly
-    async fn test_queries() {
+    async fn test_queries<T>(
+        #[values(testing::setup(), testing::setup_embedded())]
+        #[future]
+        provider_setup: (T, StrictEngine, MockKeyStore),
+    ) where
+        T: Provider + Clone + Send + Sync + 'static,
+    {
         // Insert data into store
-        let (store, index, ks) = testing::setup().await;
+        let (store, index, ks) = provider_setup.await;
 
         let api = super::routes::api(
             store.clone(),
@@ -583,9 +620,16 @@ mod test {
         // Test limit/offset
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_missing() {
-        let (store, index, ks) = testing::setup().await;
+    async fn test_missing<T>(
+        #[values(testing::setup(), testing::setup_embedded())]
+        #[future]
+        provider_setup: (T, StrictEngine, MockKeyStore),
+    ) where
+        T: Provider + Clone + Send + Sync + 'static,
+    {
+        let (store, index, ks) = provider_setup.await;
 
         let api = super::routes::api(
             store.clone(),
@@ -656,9 +700,16 @@ mod test {
         );
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_host_signed() {
-        let (store, index, ks) = testing::setup().await;
+    async fn test_host_signed<T>(
+        #[values(testing::setup(), testing::setup_embedded())]
+        #[future]
+        provider_setup: (T, StrictEngine, MockKeyStore),
+    ) where
+        T: Provider + Clone + Send + Sync + 'static,
+    {
+        let (store, index, ks) = provider_setup.await;
 
         let api = super::routes::api(
             store,

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::invoice::signature::{SecretKeyEntry, SecretKeyStorage, SignatureRole};
-#[cfg(feature = "embedded")]
 use crate::provider::embedded::EmbeddedProvider;
 use crate::provider::file::FileProvider;
 use crate::search::StrictEngine;
@@ -165,7 +164,6 @@ pub async fn setup() -> (FileProvider<StrictEngine>, StrictEngine, MockKeyStore)
 
 /// Returns an embedded `Provider` implementation configured with a temporary directory, strict
 /// Search implementation, and a mock key store for use in testing API endpoints
-#[cfg(feature = "embedded")]
 pub async fn setup_embedded() -> (EmbeddedProvider<StrictEngine>, StrictEngine, MockKeyStore) {
     let temp = tempdir().expect("unable to create tempdir");
     let index = StrictEngine::default();

--- a/tests/test_util.rs
+++ b/tests/test_util.rs
@@ -17,7 +17,7 @@ impl TestController {
     pub async fn new(server_binary_name: &str) -> TestController {
         let build_result = tokio::task::spawn_blocking(|| {
             std::process::Command::new("cargo")
-                .args(&["build", "--all-features"])
+                .args(&["build", "--features", "cli"])
                 .output()
         })
         .await


### PR DESCRIPTION
This PR adds support for a new embedded `Provider` backed by the `sled`
embedded database and with more efficient data encoding. This new
provider is behind a feature flag and is not compiled into `bindle-server`
by default. Tests have also been updated to check both providers, but
the client tests still only test with the `FileProvider`.

The motivation behind this is that the file system provider requires a bunch of
bespoke logic to check things like locking and various OS specific things. We
also have to front everything with an in-memory LRU cache. Tools like `sled`
already have most of these features built in, plus additional guarantees from
being a database (such as atomic transations and upsert commands). This also
uses a binary encoding format to store the data using less bytes and to
decrease serialization and deserialization time. All of these reasons
sounded like pretty good justification for giving it a whirl. Use of bindle
can continue as before until we decide whether we like this or not as it
is all behind a feature flag.

Any comments on open TODOs are welcome!