### PR TITLE
fix(*): Fixes flaky windows test

### DIFF
--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -86,13 +86,13 @@ async fn run() -> std::result::Result<(), ClientError> {
             }
             .await
             .map_err(map_storage_error)?;
-            tokio::fs::OpenOptions::new()
+            let mut file = tokio::fs::OpenOptions::new()
                 .write(true)
                 .create_new(true) // Make sure we aren't overwriting
                 .open(&gi_opts.output)
-                .await?
-                .write_all(&toml::to_vec(&inv)?)
                 .await?;
+            file.write_all(&toml::to_vec(&inv)?).await?;
+            file.flush().await?;
             println!(
                 "Wrote invoice {} to {}",
                 gi_opts.bindle_id,

--- a/src/invoice/signature.rs
+++ b/src/invoice/signature.rs
@@ -341,7 +341,7 @@ impl SecretKeyFile {
         let out = toml::to_vec(self)?;
         #[cfg(target_family = "unix")]
         let mut file = OpenOptions::new()
-            .create_new(true)
+            .create(true)
             .write(true)
             .mode(0o700)
             .open(dest)
@@ -352,12 +352,13 @@ impl SecretKeyFile {
         // how to set those
         #[cfg(target_family = "windows")]
         let mut file = OpenOptions::new()
-            .create_new(true)
+            .create(true)
             .write(true)
             .open(dest)
             .await?;
 
         file.write_all(&out).await?;
+        file.flush().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
After doing some digging, it looks like `flush`ing the file after write solves the problem. My theory, which I cannot entire prove, is that because the CLI stops execution, the file write did not complete, particularly on slower systems like the GH Action runners. So now we make sure to manually flush the file in places where we are not using the `write` style helper functions. I fixed this anywhere in the CLI it was not flushing. I also noticed that the logic as specified in the `create-key` command would not work with the current `save_file` method as it was using `create_new` to save the file. This changes it to `create` so that it can overwrite the existing file