### PR TITLE
Provide better errors for non-GET operations

### DIFF
--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -34,6 +34,9 @@ pub enum ClientError {
     /// The parcel was not found.
     #[error("Parcel was not found")]
     ParcelNotFound,
+
+    #[error("Requested resource or endpoint is not found")]
+    ResourceNotFound,
     /// The invoice already exists
     #[error("Invoice already exists")]
     InvoiceAlreadyExists,


### PR DESCRIPTION
All 404s were getting interpreted as missing index/parcel. Turns out some 404s occur because the endpoint is missing. So this at least tries to distinguish between the two situations.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>