### PR TITLE
fix(ci): Updates references from master

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,8 @@ jobs:
         shell: bash
         run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
-      - name: set the release version (master)
-        if: github.ref == 'refs/heads/master'
+      - name: set the release version (main)
+        if: github.ref == 'refs/heads/main'
         shell: bash
         run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
@@ -70,8 +70,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
         run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-      - name: set the release version (master)
-        if: github.ref == 'refs/heads/master'
+      - name: set the release version (main)
+        if: github.ref == 'refs/heads/main'
         shell: bash
         run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
       - name: download release assets


### PR DESCRIPTION
We forgot to change the build pipeline to look for main instead of master
so canary releases haven't been building