### PR TITLE
feat(server): Adds Github authentication support to the server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,10 +73,11 @@ dependencies = [
  "lru",
  "mime",
  "mime_guess",
+ "oauth2",
  "rand 0.7.3",
  "reqwest",
  "rstest",
- "semver",
+ "semver 0.11.0",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -159,6 +160,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "winapi",
 ]
 
@@ -497,8 +499,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -640,6 +644,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
 ]
 
 [[package]]
@@ -894,6 +913,26 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "oauth2"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e47cfc4c0a1a519d9a025ebfbac3a2439d1b5cdf397d72dcb79b11d9920dab"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.3",
+ "http",
+ "rand 0.8.4",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -1238,6 +1277,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1247,14 +1287,17 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "serde",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -1275,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "041bb0202c14f6a158bbbf086afb03d0c6e975c2dec7d4912f8061ed44f290af"
+checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -1288,11 +1331,11 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -1386,6 +1429,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
 name = "semver-parser"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,6 +1481,15 @@ checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f6109f0506e20f7e0f910e51a0079acf41da8e0694e6442527c4ddf5a2b158"
+dependencies = [
  "serde",
 ]
 
@@ -1960,6 +2018,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2124,6 +2183,15 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "clap",
  "dirs",
  "ed25519-dalek",
+ "either",
  "futures",
  "hyper",
  "lru",
@@ -317,6 +318,12 @@ dependencies = [
  "sha2",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["server", "client", "caching", "test-tools"]
 server = ["warp", "oauth2"]
-client = ["mime_guess", "dirs"]
+client = ["mime_guess", "dirs", "either"]
 caching = []
 test-tools = []
 cli = ["clap", "tracing-subscriber"]
@@ -70,6 +70,8 @@ mime = "0.3"
 sled = "0.34"
 serde_cbor = "0.11"
 oauth2 = {version = "4.1", optional = true, features = ["reqwest"]}
+# Temporary dependency on either in use for our GH auth workaround
+either = { version = "1.6", optional = true }
 
 [dev-dependencies]
 rstest = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["server", "client", "caching", "test-tools"]
-server = ["warp"]
-client = ["reqwest", "mime_guess", "dirs"]
+server = ["warp", "oauth2"]
+client = ["mime_guess", "dirs"]
 caching = []
 test-tools = []
 cli = ["clap", "tracing-subscriber"]
@@ -53,13 +53,14 @@ bytes = "1.0"
 async-trait = "0.1"
 futures = "0.3"
 clap = { version = "3.0.0-beta.2", optional = true }
-reqwest = { version = "0.11", features = ["stream"], optional = true }
+reqwest = { version = "0.11", features = ["stream"] }
 hyper = "0.14"
 url = "2.2"
 tracing-subscriber = { version = "0.2", optional = true }
 dirs = { version = "3.0", optional = true }
 mime_guess = { version = "2.0", optional = true }
 lru = "0.6"
+# We need the older version of rand for dalek
 rand = "0.7"
 ed25519-dalek = "1.0"
 base64 = "0.13"
@@ -68,9 +69,10 @@ tracing-futures = "0.2"
 mime = "0.3"
 sled = "0.34"
 serde_cbor = "0.11"
+oauth2 = {version = "4.1", optional = true, features = ["reqwest"]}
 
 [dev-dependencies]
-rstest = "0.10"
+rstest = "0.11"
 
 [[bin]]
 name = "bindle-server"

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -29,9 +29,18 @@ pub struct Opts {
     #[clap(
         short = 'r',
         long = "keyring",
+        env = "BINDLE_KEYRING",
         about = "The path to the keyring file. Defaults to $XDG_CONFIG/bindle/keyring.toml"
     )]
     pub keyring: Option<PathBuf>,
+
+    #[clap(
+        short = 't',
+        long = "token-file",
+        env = "BINDLE_TOKEN_FILE",
+        about = "The path to the login token file. If running `bindle login` this is where the file will be saved to. Defaults to $XDG_CONFIG/bindle/.token"
+    )]
+    pub token_file: Option<PathBuf>,
 
     #[clap(subcommand)]
     pub subcmd: SubCommand,
@@ -89,6 +98,11 @@ pub enum SubCommand {
         about = "Print the public key entries for keys from the secret key file. If no '--label' is supplied, public keys for all secret keys are returned."
     )]
     PrintKey(PrintKey),
+    #[clap(
+        name = "login",
+        about = "Logs in to a bindle server, saving the token locally"
+    )]
+    Login(Login),
 }
 
 #[derive(Clap)]
@@ -376,3 +390,6 @@ pub struct PushFile {
     )]
     pub media_type: Option<String>,
 }
+
+#[derive(Clap)]
+pub struct Login {}

--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,7 @@ unlicensed = "deny"
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
     "LicenseRef-ring",
+    "MPL-2.0",
 ]
 # List of explictly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -19,6 +19,10 @@ HTTP Endpoints:
 - `/_r`: The relationships endpoint. This endpoint allows for querying of various relationships between parts of a bindle.
     - `/_r/missing/{bindle-name}`: An endpoint for retrieving missing parcels in a bindle. `{bindle-name}` follows the same aforementioned rules around bindle naming
         - `GET`: Returns a list of label objects for missing parcels (i.e. parcels that haven't been uploaded). Yanked bindles are not supported by this endpoint as parcels for yanked bindles should not be uploaded
+- `/login`: Triggers a login flow for the API
+  - `GET`: Redirects to the login provider to start an OAuth2 login flow. Right now only GitHub is supported, so this endpoint is likely to change as more providers are integrated. This endpoint supports the following query parameters:
+    - `provider` (required): The name of the provider to use: For example: `provider=github`
+    - `redirect_url` (required): The redirect URL to send the code to from the login provider. For example: `redirect_url=http%3A%2F%2Flocalhost%3A8080`
 
 While bindle names MAY be hierarchical, neither the `_i` nor the `_p` endpoints support listing the contents of a URI. This constraint is for both scalability and security reasons. To list available bindles, agents MUST use the `_q` endpoint if implemented. In absence of the `_q` endpoint, this specification does not support any way to list available bindles. However, implementations MAY support alternative endpoints, provided that the URI for those endpoints does not begin with the `_` character.
 

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -20,9 +20,8 @@ HTTP Endpoints:
     - `/_r/missing/{bindle-name}`: An endpoint for retrieving missing parcels in a bindle. `{bindle-name}` follows the same aforementioned rules around bindle naming
         - `GET`: Returns a list of label objects for missing parcels (i.e. parcels that haven't been uploaded). Yanked bindles are not supported by this endpoint as parcels for yanked bindles should not be uploaded
 - `/login`: Triggers a login flow for the API
-  - `GET`: Redirects to the login provider to start an OAuth2 login flow. Right now only GitHub is supported, so this endpoint is likely to change as more providers are integrated. This endpoint supports the following query parameters:
+  - `GET`: Redirects to the login provider to start an OIDC (or OAuth2) device login flow. Right now only GitHub is supported, so this endpoint is likely to change as more providers are integrated. This endpoint supports the following query parameters:
     - `provider` (required): The name of the provider to use: For example: `provider=github`
-    - `redirect_url` (required): The redirect URL to send the code to from the login provider. For example: `redirect_url=http%3A%2F%2Flocalhost%3A8080`
 
 While bindle names MAY be hierarchical, neither the `_i` nor the `_p` endpoints support listing the contents of a URI. This constraint is for both scalability and security reasons. To list available bindles, agents MUST use the `_q` endpoint if implemented. In absence of the `_q` endpoint, this specification does not support any way to list available bindles. However, implementations MAY support alternative endpoints, provided that the URI for those endpoints does not begin with the `_` character.
 

--- a/src/authn/github.rs
+++ b/src/authn/github.rs
@@ -6,6 +6,7 @@ use super::Authenticator;
 #[derive(Clone)]
 pub struct GithubAuthenticator {
     introspection_url: String,
+    client_id: String,
     client: reqwest::Client,
 }
 
@@ -29,6 +30,7 @@ impl GithubAuthenticator {
 
         Ok(GithubAuthenticator {
             introspection_url,
+            client_id: client_id.to_owned(),
             client,
         })
     }
@@ -68,5 +70,9 @@ impl Authenticator for GithubAuthenticator {
             tracing::info!(status_code = %resp.status(), "Token validation failed");
             anyhow::bail!("Unauthorized")
         }
+    }
+
+    fn client_id(&self) -> &str {
+        &self.client_id
     }
 }

--- a/src/authn/github.rs
+++ b/src/authn/github.rs
@@ -1,0 +1,72 @@
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION};
+use reqwest::StatusCode;
+
+use super::Authenticator;
+
+#[derive(Clone)]
+pub struct GithubAuthenticator {
+    introspection_url: String,
+    client: reqwest::Client,
+}
+
+impl GithubAuthenticator {
+    pub fn new(client_id: &str, client_secret: &str) -> anyhow::Result<Self> {
+        let introspection_url = format!("https://api.github.com/applications/{}/token", client_id);
+        let mut auth_header = HeaderValue::from_str(&format!(
+            "Basic {}",
+            base64::encode(format!("{}:{}", client_id, client_secret))
+        ))?;
+        auth_header.set_sensitive(true);
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, auth_header);
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github.v3+json"),
+        );
+        let client = reqwest::ClientBuilder::new()
+            .default_headers(headers)
+            .build()?;
+
+        Ok(GithubAuthenticator {
+            introspection_url,
+            client,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Authenticator for GithubAuthenticator {
+    // TODO: Right now we have no authz stuff glued in. However, once we implement authz stuff, we
+    // can add in the information from the token introspection request
+    type Item = crate::authz::always::Anonymous;
+
+    async fn authenticate(&self, auth_data: &str) -> anyhow::Result<Self::Item> {
+        let value = serde_json::json!({
+            "access_token": auth_data,
+        });
+        let raw = serde_json::to_vec(&value).map_err(|e| {
+            // For security reasons, do not return the json error to the user, only log it
+            tracing::error!(error = %e, "Unable to serialize access token data, possible malformed data sent");
+            anyhow::anyhow!("Unauthorized")
+        })?;
+        let resp = self
+            .client
+            .post(&self.introspection_url)
+            .body(raw)
+            .send()
+            .await
+            .map_err(|e| {
+                // For security reasons, do not return the client error
+                tracing::error!(error = %e, "Unable to construct and send http request");
+                anyhow::anyhow!("Unauthorized")
+            })?;
+
+        if resp.status() == StatusCode::OK {
+            // TODO: Once we need to fetch data from the response, we can deserialize here
+            Ok(crate::authz::always::Anonymous)
+        } else {
+            tracing::info!(status_code = %resp.status(), "Token validation failed");
+            anyhow::bail!("Unauthorized")
+        }
+    }
+}

--- a/src/authn/mod.rs
+++ b/src/authn/mod.rs
@@ -16,4 +16,9 @@ pub trait Authenticator {
     /// case of a failure. This data will likely be the value of the Authorization header. Anonymous
     /// auth will be indicated by an empty auth_data string
     async fn authenticate(&self, auth_data: &str) -> anyhow::Result<Self::Item>;
+
+    /// The client_id to use for this authentication. Defaults to an empty string if not implemented
+    fn client_id(&self) -> &str {
+        ""
+    }
 }

--- a/src/authn/mod.rs
+++ b/src/authn/mod.rs
@@ -2,6 +2,7 @@
 //! feature is enabled
 
 pub mod always;
+pub mod github;
 
 use crate::authz::Authorizable;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -6,11 +6,20 @@ pub mod load;
 
 use std::convert::TryInto;
 use std::path::Path;
+use std::time::Duration;
 
+use hyper::header::{HeaderMap, HeaderValue};
+use oauth2::TokenResponse;
+use oauth2::{
+    basic::BasicTokenResponse,
+    devicecode::{DeviceAuthorizationResponse, DeviceCodeErrorResponseType},
+    StandardErrorResponse,
+};
 use reqwest::header;
 use reqwest::Client as HttpClient;
-use reqwest::ClientBuilder;
 use reqwest::{Body, RequestBuilder, StatusCode};
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
 use tokio_stream::{Stream, StreamExt};
 use tracing::{debug, info, instrument, trace};
 use url::Url;
@@ -27,7 +36,11 @@ pub type Result<T> = std::result::Result<T, ClientError>;
 pub const INVOICE_ENDPOINT: &str = "_i";
 pub const QUERY_ENDPOINT: &str = "_q";
 pub const RELATIONSHIP_ENDPOINT: &str = "_r";
+pub const LOGIN_ENDPOINT: &str = "login";
 const TOML_MIME_TYPE: &str = "application/toml";
+// TODO: Uncomment once Github is fixed
+// const GITHUB_AUTH_URL: &str = "https://github.com/login/oauth/authorize";
+const GITHUB_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
 
 /// A client type for interacting with a Bindle server
 #[derive(Clone)]
@@ -42,59 +55,69 @@ enum Operation {
     Yank,
     Get,
     Query,
+    Login,
 }
 
-/// Options for setting up a `Client`
-pub struct ClientOptions {
-    /// Controls whether the client assumes HTTP/2 or attempts to negotiate it.
-    pub http2_prior_knowledge: bool,
-    /// Controls whether the client accepts invalid certificates. The default is
-    /// to reject invalid certificates. It is sometimes necessary to set this
-    /// option in dev-test situations where you may be working with self-signed
-    /// certificates or the like.
-    pub danger_accept_invalid_certs: bool,
+/// A builder for for setting up a `Client`. Created using `Client::builder`
+pub struct ClientBuilder {
+    http2_prior_knowledge: bool,
+    danger_accept_invalid_certs: bool,
+    auth_token: Option<String>,
 }
 
-impl Default for ClientOptions {
+impl Default for ClientBuilder {
     fn default() -> Self {
         Self {
             http2_prior_knowledge: false,
             danger_accept_invalid_certs: false,
+            auth_token: None,
         }
     }
 }
 
-impl Client {
-    /// Returns a new Client with the given URL, configured using the default options.
-    /// This URL should be the FQDN plus any namespacing
-    /// (like `v1`). So if you were running a bindle server mounted at the v1 endpoint, your URL
-    /// would look something like `http://my.bindle.com/v1/`. Will return an error if the URL is not
-    /// valid
-    pub fn new(base_url: &str) -> Result<Self> {
-        Self::new_with_options(base_url, ClientOptions::default())
+impl ClientBuilder {
+    /// Controls whether the client assumes HTTP/2 or attempts to negotiate it. Defaults to false.
+    pub fn http2_prior_knowledge(mut self, http2_prior_knowledge: bool) -> Self {
+        self.http2_prior_knowledge = http2_prior_knowledge;
+        self
     }
 
-    /// Returns a new Client with the given URL, configured using the given options.
-    /// This URL should be the FQDN plus any namespacing
-    /// (like `v1`). So if you were running a bindle server mounted at the v1 endpoint, your URL
-    /// would look something like `http://my.bindle.com/v1/`. Will return an error if the URL is not
-    /// valid
-    pub fn new_with_options(base_url: &str, options: ClientOptions) -> Result<Self> {
-        // Note that the trailing slash is important, otherwise the URL parser will treat is as a
-        // "file" component of the URL. So we need to check that it is added before parsing
-        let mut base = base_url.to_owned();
-        if !base.ends_with('/') {
-            info!("Provided base URL missing trailing slash, adding...");
-            base.push('/');
+    /// Controls whether the client accepts invalid certificates. The default is to reject invalid
+    /// certificates. It is sometimes necessary to set this option in dev-test situations where you
+    /// may be working with self-signed certificates or the like. Defaults to false.
+    pub fn danger_accept_invalid_certs(mut self, danger_accept_invalid_certs: bool) -> Self {
+        self.danger_accept_invalid_certs = danger_accept_invalid_certs;
+        self
+    }
+
+    /// Sets the bearer token to use for authentication with the bindle server, if one already
+    /// exists.
+    ///
+    /// If you need to log in, you can set the token after constructing the `Client` with
+    /// [`set_auth_token`](Client::set_auth_token)
+    pub fn auth_token(mut self, token: String) -> Self {
+        self.auth_token = Some(token);
+        self
+    }
+
+    /// Returns a new Client with the given URL, configured using the set options. If you want to
+    /// build a client while logging into a server, use [`ClientBuilder::login`]
+    ///
+    /// This URL should be the FQDN plus any namespacing (like `v1`). So if you were running a
+    /// bindle server mounted at the v1 endpoint, your URL would look something like
+    /// `http://my.bindle.com/v1/`. Will return an error if the URL is not valid
+    pub fn build(self, base_url: &str) -> Result<Client> {
+        let (base_parsed, mut headers) = base_url_and_headers(base_url)?;
+        if let Some(token) = self.auth_token {
+            let mut header_val = HeaderValue::from_str(&format!("Bearer {}", token))
+                .map_err(|e| ClientError::Other(e.to_string()))?;
+            header_val.set_sensitive(true);
+            headers.insert(header::AUTHORIZATION, header_val);
         }
-        let base_parsed = Url::parse(&base)?;
-        let mut headers = header::HeaderMap::new();
-        headers.insert(header::ACCEPT, "application/toml".parse().unwrap());
-        // TODO: As this evolves, we might want to allow for setting time outs and accepting
-        // self-signed certs
+
         let client = HttpClient::builder()
-            .and_if(options.http2_prior_knowledge, |b| b.http2_prior_knowledge())
-            .and_if(options.danger_accept_invalid_certs, |b| {
+            .and_if(self.http2_prior_knowledge, |b| b.http2_prior_knowledge())
+            .and_if(self.danger_accept_invalid_certs, |b| {
                 b.danger_accept_invalid_certs(true)
             })
             .default_headers(headers)
@@ -104,6 +127,230 @@ impl Client {
             client,
             base_url: base_parsed,
         })
+    }
+
+    /// Logs in to a bindle server, saving the access_token at the configured path (it will
+    /// overwrite any existing data at the path), and then returning a new client configured with
+    /// that token.
+    ///
+    /// Please note that this function requires user interaction. It will request a device code for
+    /// logging in to the CLI, which requires a user to do so in a browser. This information will be
+    /// printed to STDOUT
+    pub async fn login(mut self, base_url: &str, token_path: impl AsRef<Path>) -> Result<Client> {
+        let (base_parsed, headers) = base_url_and_headers(base_url)?;
+
+        let client = HttpClient::builder()
+            .and_if(self.http2_prior_knowledge, |b| b.http2_prior_knowledge())
+            .and_if(self.danger_accept_invalid_certs, |b| {
+                b.danger_accept_invalid_certs(true)
+            })
+            .default_headers(headers.clone())
+            .build()
+            .map_err(|e| ClientError::Other(e.to_string()))?;
+        let login_resp = client
+            .get(base_parsed.join(LOGIN_ENDPOINT).unwrap())
+            .query(&crate::LoginParams {
+                provider: crate::LoginProvider::Github,
+            })
+            .send()
+            .await?;
+        let login_resp = unwrap_status(login_resp, Endpoint::Login, Operation::Login).await?;
+        let device_code_details: DeviceAuthorizationResponse<
+            crate::DeviceAuthorizationExtraFields,
+        > = toml::from_slice(&login_resp.bytes().await?)?;
+
+        println!(
+            "Open this URL in your browser:\n{}\nand then enter the code when prompted: {}",
+            device_code_details.verification_uri().to_string(),
+            device_code_details.user_code().secret().to_string()
+        );
+
+        // HACK(thomastaylor312): Please note that this is how things should work (for pretty much
+        // any device flow), but Github's is in beta and it doesn't return the proper status code
+        // (400) when the user hasn't logged in yet per RFC 8628 section 3.5 and RFC 6749 section
+        // 5.2. So the code completely chokes. Instead we are doing the check manually
+
+        // let oauth_client = BasicClient::new(
+        //     ClientId::new(device_code_details.extra_fields().client_id.clone()),
+        //     None,
+        //     AuthUrl::new(GITHUB_AUTH_URL.to_owned()).unwrap(),
+        //     Some(TokenUrl::new(GITHUB_TOKEN_URL.to_owned()).unwrap()),
+        // );
+
+        // let token_res = match oauth_client
+        //     .exchange_device_access_token(&device_code_details)
+        //     .request_async(async_http_client, tokio::time::sleep, None)
+        //     .await
+        // {
+        //     Ok(t) => t,
+        //     Err(e) => {
+        //         if let oauth2::RequestTokenError::Parse(err, d) = &e {
+        //             println!("Data: {}", String::from_utf8_lossy(&d));
+        //         }
+        //         return Err(ClientError::Other(format!("{:?}", e)));
+        //     }
+        // };
+
+        // let token = token_res.access_token();
+
+        let token = wait_for_auth(device_code_details).await?;
+
+        tracing::info!(path = %token_path.as_ref().display(), "Writing access token to file");
+
+        #[cfg(not(target_family = "windows"))]
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .mode(0o600)
+            .open(token_path)
+            .await?;
+
+        // TODO: Figure out the proper permission for a token on disk for windows
+        #[cfg(target_family = "windows")]
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(token_path)
+            .await?;
+
+        file.write_all(token.as_bytes()).await?;
+
+        self.auth_token = Some(token);
+
+        // Because we can't consume the client and reuse the config, we just need to reconfigure the
+        // whole thing
+        self.build(base_parsed.as_str())
+    }
+}
+
+async fn wait_for_auth(
+    device_code_details: DeviceAuthorizationResponse<crate::DeviceAuthorizationExtraFields>,
+) -> Result<String> {
+    // Add a little wiggle room on the interval
+    let mut interval =
+        tokio::time::interval(device_code_details.interval() + Duration::from_secs(1));
+    // Just skip if we miss a tick so we don't get slow down responses
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Get the maximum time we should wait from the details. We are subtracting the interval from
+    // the max duration so that we have a buffer of time at the end rather than triggering a code
+    // expired error on the last tick
+    let timeout = device_code_details.expires_in() + device_code_details.interval();
+
+    let mut headers = header::HeaderMap::new();
+    headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+    headers.insert(header::CONTENT_TYPE, "application/json".parse().unwrap());
+
+    let client = reqwest::ClientBuilder::new()
+        .default_headers(headers)
+        .build()?;
+
+    loop {
+        let elapsed = interval.tick().await;
+        if elapsed.elapsed() >= timeout {
+            return Err(ClientError::Other(
+                "Timeout reached for device code auth. Please login again".into(),
+            ));
+        }
+
+        tracing::debug!("Checking for access token");
+
+        let res = client
+            .post(GITHUB_TOKEN_URL)
+            .body(
+                serde_json::to_vec(&serde_json::json!({
+                    "client_id": device_code_details.extra_fields().client_id,
+                    "device_code": device_code_details.device_code().secret(),
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                }))
+                .expect("Unable to serialize auth token body. This is programmer error"),
+            )
+            .send()
+            .await?;
+
+        match parse_response(res).await? {
+            either::Left(e) => {
+                match e.error() {
+                    DeviceCodeErrorResponseType::AuthorizationPending => {
+                        tracing::debug!(retry_interval = ?device_code_details.interval(), "Device authorization still pending, will retry");
+                        continue
+                    }
+                    DeviceCodeErrorResponseType::SlowDown => tracing::warn!("Token polling operation occurred too quickly, will retry"),
+                    DeviceCodeErrorResponseType::ExpiredToken => return Err(ClientError::Other(e.error_description().map(|s| s.to_owned()).unwrap_or_else(|| "Device login token has expired".into()))),
+                    _ => return Err(ClientError::Other(format!("Unable to continue with device authentication, got error of type {} with description '{}' and error_uri of '{}'", e.error(), e.error_description().map(|s| s.to_owned()).unwrap_or_default(), e.error_uri().map(|s| s.to_owned()).unwrap_or_default())))
+                }
+            }
+            either::Right(s) => {
+                return Ok(s.access_token().secret().to_owned())
+            }
+        }
+    }
+}
+
+async fn parse_response(
+    resp: reqwest::Response,
+) -> Result<either::Either<StandardErrorResponse<DeviceCodeErrorResponseType>, BasicTokenResponse>>
+{
+    let status = resp.status();
+    let raw = resp.bytes().await?;
+    if !status.is_success() {
+        return Err(ClientError::Other(format!(
+            "Got non-success response from Github (status code {}) with the following body: {}",
+            status,
+            String::from_utf8_lossy(&raw)
+        )));
+    }
+
+    // First attempt to parse as an error, if that fails, then parse it as a success
+    match serde_json::from_slice::<StandardErrorResponse<DeviceCodeErrorResponseType>>(&raw) {
+        Ok(r) => return Ok(either::Left(r)),
+        // This means it was a parse error so it isn't an error response
+        Err(e) if e.is_syntax() || e.is_data() => (),
+        Err(_) => {
+            return Err(ClientError::Other(format!(
+                "Invalid data received from Github: {}",
+                String::from_utf8_lossy(&raw)
+            )))
+        }
+    }
+
+    // If we got here, it is probably a success response
+    Ok(either::Right(serde_json::from_slice(&raw).map_err(
+        |_| {
+            ClientError::Other(format!(
+                "Invalid success response received from Github: {}",
+                String::from_utf8_lossy(&raw)
+            ))
+        },
+    )?))
+}
+
+fn base_url_and_headers(base_url: &str) -> Result<(Url, HeaderMap)> {
+    // Note that the trailing slash is important, otherwise the URL parser will treat is as a
+    // "file" component of the URL. So we need to check that it is added before parsing
+    let mut base = base_url.to_owned();
+    if !base.ends_with('/') {
+        info!("Provided base URL missing trailing slash, adding...");
+        base.push('/');
+    }
+    let base_parsed = Url::parse(&base)?;
+    let mut headers = header::HeaderMap::new();
+    headers.insert(header::ACCEPT, TOML_MIME_TYPE.parse().unwrap());
+    Ok((base_parsed, headers))
+}
+
+impl Client {
+    /// Returns a new Client with the given URL, configured using the default options.
+    ///
+    /// This URL should be the FQDN plus any namespacing (like `v1`). So if you were running a
+    /// bindle server mounted at the v1 endpoint, your URL would look something like
+    /// `http://my.bindle.com/v1/`. Will return an error if the URL is not valid
+    pub fn new(base_url: &str) -> Result<Self> {
+        ClientBuilder::default().build(base_url)
+    }
+
+    /// Returns a [`ClientBuilder`](ClientBuilder) configured with defaults
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
     }
 
     /// Performs a raw request using the underlying HTTP client and returns the raw response. The
@@ -546,6 +793,9 @@ enum Endpoint {
     Invoice,
     Parcel,
     Query,
+    // NOTE: This endpoint currently does nothing, but if we need more specific errors, we can use
+    // this down the line
+    Login,
 }
 
 async fn unwrap_status(
@@ -610,4 +860,4 @@ trait ConditionalBuilder {
     }
 }
 
-impl ConditionalBuilder for ClientBuilder {}
+impl ConditionalBuilder for reqwest::ClientBuilder {}

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -12,6 +12,8 @@ pub mod signature;
 pub mod verification;
 
 #[doc(inline)]
+pub(crate) use api::{DeviceAuthorizationExtraFields, LoginParams, LoginProvider};
+#[doc(inline)]
 pub use api::{ErrorResponse, InvoiceCreateResponse, MissingParcelsResponse, QueryOptions};
 #[doc(inline)]
 pub use bindle_spec::BindleSpec;

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -69,6 +69,8 @@ pub mod v1 {
     pub mod auth {
         use super::*;
 
+        use crate::LoginParams;
+
         pub fn login(
             provider_client_id: String,
         ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -63,6 +63,20 @@ pub mod v1 {
 
     use warp::Filter;
 
+    pub mod auth {
+        use super::*;
+
+        pub fn login(
+            provider_client_id: String,
+        ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+            warp::path("login")
+                .and(warp::get())
+                .and(warp::query::<LoginParams>())
+                .and(warp::any().map(move || provider_client_id.clone()))
+                .and_then(crate::server::handlers::v1::login)
+        }
+    }
+
     pub mod invoice {
         use crate::{
             server::routes::with_secret_store,

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -24,35 +24,38 @@ where
 {
     // Use an Arc to avoid a possibly expensive clone of the keyring on every API call
     let wrapped_keyring = Arc::new(keyring);
-    warp::path("v1")
-        .and(filters::authenticate_and_authorize(authn, authz))
-        .untuple_one()
-        .and(
-            v1::invoice::query(index)
-                .or(v1::invoice::create_toml(
-                    store.clone(),
-                    secret_store.clone(),
-                    verification_strategy.clone(),
-                    wrapped_keyring.clone(),
-                ))
-                .or(v1::invoice::create_json(
-                    store.clone(),
-                    secret_store,
-                    verification_strategy,
-                    wrapped_keyring,
-                ))
-                .or(v1::invoice::get(store.clone()))
-                .or(v1::invoice::head(store.clone()))
-                .or(v1::invoice::yank(store.clone()))
-                .or(v1::parcel::create(store.clone()))
-                .or(v1::parcel::get(store.clone()))
-                .or(v1::parcel::head(store.clone()))
-                .or(v1::relationships::get_missing_parcels(store)),
-        )
-        .recover(filters::handle_invalid_request_path)
-        .recover(filters::handle_authn_rejection)
-        .recover(filters::handle_authz_rejection)
-        .with(warp::trace::request())
+    warp::path("v1").and(
+        v1::auth::login(authn.client_id().to_owned())
+            .with(warp::trace::request())
+            .or(filters::authenticate_and_authorize(authn.clone(), authz)
+                .untuple_one()
+                .and(
+                    v1::invoice::query(index)
+                        .or(v1::invoice::create_toml(
+                            store.clone(),
+                            secret_store.clone(),
+                            verification_strategy.clone(),
+                            wrapped_keyring.clone(),
+                        ))
+                        .or(v1::invoice::create_json(
+                            store.clone(),
+                            secret_store,
+                            verification_strategy,
+                            wrapped_keyring,
+                        ))
+                        .or(v1::invoice::get(store.clone()))
+                        .or(v1::invoice::head(store.clone()))
+                        .or(v1::invoice::yank(store.clone()))
+                        .or(v1::parcel::create(store.clone()))
+                        .or(v1::parcel::get(store.clone()))
+                        .or(v1::parcel::head(store.clone()))
+                        .or(v1::relationships::get_missing_parcels(store)),
+                )
+                .recover(filters::handle_invalid_request_path)
+                .recover(filters::handle_authn_rejection)
+                .recover(filters::handle_authz_rejection)
+                .with(warp::trace::request())),
+    )
 }
 
 pub mod v1 {
@@ -73,6 +76,7 @@ pub mod v1 {
                 .and(warp::get())
                 .and(warp::query::<LoginParams>())
                 .and(warp::any().map(move || provider_client_id.clone()))
+                .and(warp::header::optional::<String>("accept"))
                 .and_then(crate::server::handlers::v1::login)
         }
     }


### PR DESCRIPTION
So this is a bit gnarly here, but functional. Basically, the login flow goes like this:

Client calls `/login` endpoint with their desired provider -> bindle server starts device code flow ->
bindle server returns auth code details to client -> client calls proper endpoint to retrieve token

On every API call, the passed token will be validated against the auth provider. We will likely
want to optimize this with some sort of cache in the future. Ideally, we can add other providers
in the future using OIDC.

Closes #209 