### PR TITLE
add --format to search

### DIFF
--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -168,7 +168,7 @@ The range modifiers will include the following modifiers, all based on the Node.
 - `~` -- at least the given version
 "#;
 
-#[derive(Clap)]
+#[derive(Clap, Clone)]
 pub struct Search {
     // TODO: Figure out output format (like tables)
     #[clap(
@@ -197,6 +197,13 @@ pub struct Search {
         about = "Whether or not to include yanked bindles in the search result"
     )]
     pub yanked: Option<bool>,
+    #[clap(
+        short = 'f',
+        long = "output-format",
+        about = "choose an output format",
+        possible_values = &["json", "toml", "table"],
+    )]
+    pub output: Option<String>,
 }
 
 impl From<Search> for bindle::QueryOptions {

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -13,11 +13,13 @@ pub enum ClientError {
     #[error("Error while performing IO operation")]
     Io(#[from] std::io::Error),
     /// Invalid TOML parsing that can occur when loading an invoice or label from disk
-    #[error("Invalid toml")]
+    #[error("Invalid TOML")]
     InvalidToml(#[from] toml::de::Error),
     /// Invalid TOML serialization that can occur when serializing an object to a request
-    #[error("Invalid toml")]
+    #[error("Failed serializing TOML")]
     TomlSerializationError(#[from] toml::ser::Error),
+    #[error("Failed serializing JSON")]
+    JsonSerializationError(#[from] serde_json::Error),
     /// There was a problem with the http client. This is likely not a user issue. Contains the
     /// underlying error
     #[error("Error creating request")]


### PR DESCRIPTION
Add support for `-f`|`--format`. (Note that I didn't use `-o`|`--output` because we have already used it as a flag for output files)

The new formatter gives users the choice between `table` (new default), `toml`, and `json`. It is easy enough to add other serializers.

New default output:

```console
$ bindle search -q example
example.com/hello/1.0.0:        Autogenerated example bindle for Wagi
example.com/hello/1.1.0:        Autogenerated example bindle for Wagi
example.com/hello/1.2.0:        Autogenerated example bindle for Wagi
example.com/hello/1.3.0:        Autogenerated example bindle for Wagi
example.com/hello/1.3.1:        Autogenerated example bindle for Wagi
example.com/hello/1.3.2:        Autogenerated example bindle for Wagi
example.com/hello/1.3.3:        Autogenerated example bindle for Wagi
example.com/hello/1.4.0:        Autogenerated example bindle for Wagi
=== Showing results 1 to 8 of 8 (limit: 50)
```

In case the results are beyond the limit:

```console
$ bindle search -q example -f table --limit 5
example.com/hello/1.0.0:        Autogenerated example bindle for Wagi
example.com/hello/1.1.0:        Autogenerated example bindle for Wagi
example.com/hello/1.2.0:        Autogenerated example bindle for Wagi
example.com/hello/1.3.0:        Autogenerated example bindle for Wagi
example.com/hello/1.3.1:        Autogenerated example bindle for Wagi
=== Showing results 1 to 5 of 8 (limit: 5) - More results are available with --offset=8
```

And new JSON support:

```console
bindle search -q example -f json --limit 1
{
  "query": "example",
  "strict": true,
  "offset": 0,
  "limit": 1,
  "total": 8,
  "more": true,
  "yanked": false,
  "invoices": [
    {
      "bindleVersion": "1.0.0",
      "yanked": null,
      "yankedSignature": null,
      "bindle": {
        "name": "example.com/hello",
        "version": "1.0.0",
        "description": "Autogenerated example bindle for Wagi",
        "authors": null
      },
      "annotations": null,
      "parcel": [
        {
          "label": {
            "sha256": "1f2bc60e4e39297d9a3fd06b789f6f00fac4272d72da6bf5dae20fb5f32d45a4",
            "mediaType": "application/wasm",
            "name": "examples/hello.wasm",
            "size": 165,
            "annotations": null,
            "feature": {
              "wagi": {
                "route": "/"
              }
            },
            "origin": null
          },
          "conditions": null
        }
      ],
      "group": null,
      "signature": null
    }
  ]
}%    
```


BREAKING: TOML support now requiers the `--format toml` arg.

Closes #208

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>