### PR TITLE
add HTTP Basic Auth to the client and the server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,12 +58,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bcrypt"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f691e63585950d8c1c43644d11bab9073e40f5060dd2822734ae7c3dc69a3a80"
+dependencies = [
+ "base64",
+ "blowfish",
+ "getrandom 0.2.3",
+]
+
+[[package]]
 name = "bindle"
 version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "bcrypt",
  "bytes",
  "clap",
  "dirs",
@@ -110,6 +122,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3ff3fc1de48c1ac2e3341c4df38b0d1bfb8fdf04632a187c8b75aaa319a7ab"
+dependencies = [
+ "byteorder",
+ "cipher",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -163,6 +186,15 @@ dependencies = [
  "num-traits",
  "serde",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ serde_cbor = "0.11"
 oauth2 = {version = "4.1", optional = true, features = ["reqwest"]}
 # Temporary dependency on either in use for our GH auth workaround
 either = { version = "1.6", optional = true }
+bcrypt = "0.10"
 
 [dev-dependencies]
 rstest = "0.11"

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ MIME ?= "application/toml"
 CERT_NAME ?= ssl-example
 TLS_OPTS ?= --tls-cert $(CERT_NAME).crt.pem --tls-key $(CERT_NAME).key.pem
 EMBEDDED_FLAG ?= --use-embedded-db true
+AUTH_MODE ?=
+# Example of HTTP basic auth with the testing fixture data. 
+#AUTH_MODE ?= --htpasswd-file test/data/htpasswd
 
 export RUST_LOG=error,warp=info,bindle=$(BINDLE_LOG_LEVEL)
 
@@ -58,7 +61,7 @@ serve-embedded-tls: _run
 
 .PHONY: _run
 _run:
-	cargo run $(SERVER_FEATURES) --bin $(SERVER_BIN) -- --directory $(BINDLE_DIRECTORY) --address $(BINDLE_IFACE) $(TLS_OPTS) $(EMBEDDED_FLAG)
+	cargo run $(SERVER_FEATURES) --bin $(SERVER_BIN) -- --directory $(BINDLE_DIRECTORY) --address $(BINDLE_IFACE) $(TLS_OPTS) $(EMBEDDED_FLAG) $(AUTH_MODE)
 
 # Sort of a wacky hack if you want to do `$(make client) --help`
 .PHONY: client

--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -84,6 +84,10 @@ async fn run() -> std::result::Result<(), ClientError> {
         builder = builder.auth_token(t);
     }
 
+    if let Some(user) = opts.http_user {
+        builder = builder.user_password(user, opts.http_password.unwrap_or_default());
+    }
+
     let bindle_client = builder.build(&opts.server_url)?;
 
     // TODO(thomastaylor312): We should read the token using a JWT parser and see if it is still

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -42,6 +42,16 @@ pub struct Opts {
     )]
     pub token_file: Option<PathBuf>,
 
+    #[clap(
+        long = "http-user",
+        about = "Username for HTTP Basic auth",
+        requires = "http-password"
+    )]
+    pub http_user: Option<String>,
+
+    #[clap(long = "http-password", about = "Password for HTTP Basic auth")]
+    pub http_password: Option<String>,
+
     #[clap(subcommand)]
     pub subcmd: SubCommand,
 }

--- a/bin/server.rs
+++ b/bin/server.rs
@@ -1,5 +1,5 @@
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Clap;
 use tracing::{info, warn};
@@ -11,6 +11,15 @@ use bindle::{
     signature::SecretKeyFile,
     SecretKeyEntry,
 };
+
+enum AuthType {
+    /// Use GitHub with the given Client Id and Secret (in that order)
+    Github(String, String),
+    /// Use an HTPassword file at the given path
+    HttpBasic(PathBuf),
+    /// Do not perform auth.
+    None,
+}
 
 const DESCRIPTION: &str = r#"
 The Bindle Server
@@ -111,6 +120,14 @@ struct Opts {
         about = "The Github client secret to use for Oauth2 token authentication. --github-client-id should be set as well. Please note this flag is likely to be changed or removed in future releases"
     )]
     github_client_secret: Option<String>,
+
+    #[clap(
+        name = "htpasswd-file",
+        long = "htpasswd-file",
+        env = "BINDLE_HTPASSWD_FILE",
+        about = "If set, this will turn on HTTP Basic Auth for Bindle and load the given htpasswd file. Use 'htpasswd -Bc' to create one."
+    )]
+    htpasswd_file: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -233,24 +250,32 @@ async fn main() -> anyhow::Result<()> {
         bindle_directory.display()
     );
 
+    let auth_method = if opts.github_client_id.is_some() {
+        AuthType::Github(
+            opts.github_client_id.unwrap(),
+            opts.github_client_secret.unwrap(),
+        )
+    } else if let Some(htpasswd) = opts.htpasswd_file {
+        AuthType::HttpBasic(htpasswd)
+    } else {
+        AuthType::None
+    };
+
     // TODO: This is really gnarly, but the associated type on `Authenticator` makes turning it into
     // a Boxed dynner really difficult. I also tried rolling our own type erasure and ran into
     // similar issues (though I think it could be fixed, it would be a lot of code). So we might
     // have to resort to some sort of dependency injection here. The same goes for providers as the
     // methods have generic parameters
-    match (opts.use_embedded_db, opts.github_client_id.is_some()) {
+    match (opts.use_embedded_db, auth_method) {
         // Embedded DB and GH auth
-        (true, true) => {
+        (true, AuthType::Github(id, secret)) => {
             warn!("Using EmbeddedProvider. This is currently experimental");
             info!("Using Github Oauth token authentication");
             let store =
                 provider::embedded::EmbeddedProvider::new(&bindle_directory, index.clone()).await?;
             // We can unwrap safely here because Clap checks that both args exist and we already
             // checked that one of them exists
-            let authn = bindle::authn::github::GithubAuthenticator::new(
-                &opts.github_client_id.unwrap(),
-                &opts.github_client_secret.unwrap(),
-            )?;
+            let authn = bindle::authn::always::AlwaysAuthenticate; //bindle::authn::github::GithubAuthenticator::new(&id, &secret)?;
             server(
                 store,
                 index,
@@ -265,7 +290,7 @@ async fn main() -> anyhow::Result<()> {
             .await
         }
         // Embedded DB and no GH auth
-        (true, false) => {
+        (true, AuthType::None) => {
             warn!("Using EmbeddedProvider. This is currently experimental");
             let store =
                 provider::embedded::EmbeddedProvider::new(&bindle_directory, index.clone()).await?;
@@ -283,16 +308,13 @@ async fn main() -> anyhow::Result<()> {
             .await
         }
         // File system and GH auth
-        (false, true) => {
+        (false, AuthType::Github(id, secret)) => {
             info!("Using FileProvider");
             info!("Using Github Oauth token authentication");
             let store = provider::file::FileProvider::new(&bindle_directory, index.clone()).await;
             // We can unwrap safely here because Clap checks that both args exist and we already
             // checked that one of them exists
-            let authn = bindle::authn::github::GithubAuthenticator::new(
-                &opts.github_client_id.unwrap(),
-                &opts.github_client_secret.unwrap(),
-            )?;
+            let authn = bindle::authn::always::AlwaysAuthenticate; //bindle::authn::github::GithubAuthenticator::new(&id, &secret)?;
             server(
                 store,
                 index,
@@ -307,13 +329,52 @@ async fn main() -> anyhow::Result<()> {
             .await
         }
         // File system and no GH auth
-        (false, false) => {
+        (false, AuthType::None) => {
             info!("Using FileProvider");
             let store = provider::file::FileProvider::new(&bindle_directory, index.clone()).await;
             server(
                 store,
                 index,
                 bindle::authn::always::AlwaysAuthenticate,
+                bindle::authz::always::AlwaysAuthorize,
+                addr,
+                tls,
+                secret_store,
+                strategy,
+                keyring,
+            )
+            .await
+        }
+        // DB with HttpBasic
+        (true, AuthType::HttpBasic(filename)) => {
+            warn!("Using EmbeddedProvider. This is currently experimental");
+            info!("Auth mode: HTTP Basic Auth");
+            let store =
+                provider::embedded::EmbeddedProvider::new(&bindle_directory, index.clone()).await?;
+            let authn = bindle::authn::http_basic::HttpBasic::from_file(filename).await?;
+            server(
+                store,
+                index,
+                authn,
+                bindle::authz::always::AlwaysAuthorize,
+                addr,
+                tls,
+                secret_store,
+                strategy,
+                keyring,
+            )
+            .await
+        }
+        // File system with HttpBasic
+        (false, AuthType::HttpBasic(filename)) => {
+            info!("Using FileProvider");
+            info!("Auth mode: HTTP Basic Auth");
+            let authn = bindle::authn::http_basic::HttpBasic::from_file(filename).await?;
+            let store = provider::file::FileProvider::new(&bindle_directory, index.clone()).await;
+            server(
+                store,
+                index,
+                authn,
                 bindle::authz::always::AlwaysAuthorize,
                 addr,
                 tls,

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,6 +118,34 @@ myname = "myvalue"
 
 To learn more about the Bindle command, run `bindle --help`.
 
+### Configuring Authentication
+
+There are currently two authentication types supported by Bindle:
+
+- GitHub OAuth2
+- HTTP Basic Auth (username/password)
+
+To use GitHub OAuth2, you must supply `--github-client-id` and `--github-client-secret` at startup.
+
+To use HTTP Basic authentication, you must generate an `htpasswd` file using Bcrypt:
+
+```console
+$ htpasswd -Bc htpasswd admin
+New password: 
+Re-type new password: 
+Adding password for user admin
+```
+
+(The `htpasswd` program comes on many Linux/Unix distros. Officially it is part of the Apache Web Server project.)
+
+Then you need to supply the `--htpasswd-file` option at `bindle-server` startup:
+
+```console
+$ bindle-server --htpasswd-file test/data/htpasswd
+```
+
+> Currently, only bcrypt is supported in htpasswd files. At the time of this writing, bcrypt is the most secure algorithm supported by htpasswd.
+
 ### Configuring Signing
 
 Keys are used for signing and verification.

--- a/src/authn/http_basic.rs
+++ b/src/authn/http_basic.rs
@@ -1,0 +1,139 @@
+use std::{collections::HashMap, path::Path};
+
+use super::Authenticator;
+use crate::authz::always::Anonymous;
+
+/// HTTP header prefix
+const HTTP_BASIC_PREFIX: &str = "Basic ";
+
+/// An authenticator that simply returns an anonymous user
+///
+/// In basic auth, the auth_data will come in as 'Basic BASE64_STRING', where
+/// the Base-64 string is the username and password separated by a colon.
+///
+/// This tool splits username and password, looks up the user in the database,
+/// and then compares the hashed password to the hash returned by the database.
+#[derive(Clone, Debug)]
+pub struct HttpBasic {
+    authmap: HashMap<String, String>,
+}
+
+impl HttpBasic {
+    /// Read an htpasswd-formatted file.
+    ///
+    /// This only supports SHA1, though we should switch to bcrypt if there is a good lib.
+    ///
+    /// Example htpassword entry for a bcrypt hash:
+    ///
+    /// > myName:$2y$05$c4WoMPo3SXsafkva.HHa6uXQZWr7oboPiC2bT/r7q1BB8I2s0BRqC
+    ///
+    /// See https://httpd.apache.org/docs/2.4/misc/password_encryptions.html
+    pub async fn from_file(authfile: impl AsRef<Path>) -> anyhow::Result<Self> {
+        // Load the file
+        let raw = tokio::fs::read_to_string(&authfile).await?;
+        // Parse the records into a map
+        let mut authmap = HashMap::new();
+        for line in raw.split_terminator('\n') {
+            // Each line is username:{hash}value
+            let pair: Vec<&str> = line.splitn(2, ':').collect();
+            authmap.insert(pair[0].to_owned(), pair[1].to_owned());
+        }
+        // Attach the map to the struct
+        Ok(HttpBasic { authmap })
+    }
+
+    fn check_credentials(&self, username: String, password: String) -> bool {
+        // Note that it is consider a security risk to leak any information about
+        // why an auth failed. So returning a bool provides the minimal info necessary.
+        match self.authmap.get(&username) {
+            Some(ciphertext) => {
+                if ciphertext.starts_with("$2y$") {
+                    match bcrypt::verify(password, ciphertext) {
+                        Err(e) => {
+                            tracing::warn!(%e, "Error verifying bcrypted passwd");
+                            false
+                        }
+                        Ok(res) => res,
+                    }
+                } else {
+                    tracing::warn!("htpasswd has entries in the wrong format.");
+                    false
+                }
+            }
+            None => {
+                // Intentionally waste time to prevent timing attacks from disclosing
+                // the presence or absence of a user ID. The number of rounds ($07$) will
+                // control how long this takes. Higher is longer.
+                let _ = bcrypt::verify(
+                    username,
+                    "$2y$07$QCVM96JWmNWzx3k/7g1UXOLAO2y0imHGNjzEVkQoikrsV3gd4Xqk6",
+                );
+                false
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Authenticator for HttpBasic {
+    // TODO: When Authz is plumbed in, we should be more specific.
+    type Item = Anonymous;
+
+    async fn authenticate(&self, auth_data: &str) -> anyhow::Result<Self::Item> {
+        if auth_data.is_empty() {
+            anyhow::bail!("Username and password are required")
+        }
+
+        let (username, password) = parse_basic(auth_data)?;
+        match self.check_credentials(username, password) {
+            true => Ok(Anonymous),
+            false => anyhow::bail!("Authentication failed"),
+        }
+    }
+}
+
+fn parse_basic(auth_data: &str) -> anyhow::Result<(String, String)> {
+    match auth_data.strip_prefix(HTTP_BASIC_PREFIX) {
+        None => anyhow::bail!("Wrong auth type. Only Basic auth is supported"),
+        Some(suffix) => {
+            // suffix should be base64 string
+            let decoded = String::from_utf8(base64::decode(suffix)?)?;
+            let pair: Vec<&str> = decoded.splitn(2, ':').collect();
+            Ok((pair[0].to_owned(), pair[1].to_owned()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_parse_basic() {
+        let (name, pw) =
+            super::parse_basic("Basic YWRtaW46c3cwcmRmMXNo").expect("Basic header should parse");
+        assert_eq!("admin", name);
+        assert_eq!("sw0rdf1sh", pw, "the password is always swordfish");
+
+        super::parse_basic("NotBasic fadsfasdjkfhsadkjfhkashdfa").expect_err("Not a Basic header");
+    }
+
+    #[tokio::test]
+    async fn test_load_and_auth() {
+        let authfile = "test/data/htpasswd";
+        let basic = super::HttpBasic::from_file(authfile)
+            .await
+            .expect("File should load");
+        assert!(
+            basic.check_credentials("admin".to_owned(), "sw0rdf1sh".to_owned()),
+            "The password is always swordfish"
+        );
+
+        assert!(
+            !basic.check_credentials("nope".to_owned(), "password".to_owned()),
+            "should fail on nonexistent user"
+        );
+        assert!(
+            !basic.check_credentials("admin".to_owned(), "swordfish".to_owned()),
+            "The password is not swordfish"
+        );
+    }
+}

--- a/src/authn/mod.rs
+++ b/src/authn/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod always;
 pub mod github;
+pub mod http_basic;
 
 use crate::authz::Authorizable;
 

--- a/test/data/htpasswd
+++ b/test/data/htpasswd
@@ -1,0 +1,1 @@
+admin:$2y$05$zwK38cRDnjubAni5GRD3deZSvjMixQLVF6XYeKQrCAtzaWRZT8Xdi


### PR DESCRIPTION
This adds support for HTTP Basic Auth. Per the docs/README.md:

To use HTTP Basic authentication, you must generate an `htpasswd` file using Bcrypt:

```console
$ htpasswd -Bc htpasswd admin
New password: 
Re-type new password: 
Adding password for user admin
```

(The `htpasswd` program comes on many Linux/Unix distros. Officially it is part of the Apache Web Server project.)

Then you need to supply the `--htpasswd-file` option at `bindle-server` startup:

```console
$ bindle-server --htpasswd-file test/data/htpasswd
```

> Currently, only bcrypt is supported in htpasswd files. At the time of this writing, bcrypt is the most secure algorithm supported by htpasswd.

Closes #217

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>