### PR TITLE
feat(server): Adds anonymous auth support for get endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "clap",
  "dirs",
  "ed25519-dalek",
+ "either",
  "futures",
  "hyper",
  "indexmap",
@@ -394,6 +395,12 @@ dependencies = [
  "sha2",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ jsonwebtoken = "7.2"
 openid = {version = "0.9", optional = true}
 bcrypt = "0.10"
 chrono = { version = "0.4", features = ["serde"], optional = true }
+either = "1.6"
 
 # NOTE: This is a workaround due to a dependency issue in oauth2: https://github.com/tkaitchuck/ahash/issues/95#issuecomment-903560879
 indexmap = "~1.6.2"

--- a/bin/server.rs
+++ b/bin/server.rs
@@ -296,7 +296,7 @@ async fn main() -> anyhow::Result<()> {
                 store,
                 index,
                 authn,
-                bindle::authz::always::AlwaysAuthorize,
+                bindle::authz::anonymous_get::AnonymousGet,
                 addr,
                 tls,
                 secret_store,
@@ -305,7 +305,7 @@ async fn main() -> anyhow::Result<()> {
             )
             .await
         }
-        // Embedded DB and no GH auth
+        // Embedded DB and no auth
         (true, AuthType::None) => {
             warn!("Using EmbeddedProvider. This is currently experimental");
             let store =
@@ -336,7 +336,7 @@ async fn main() -> anyhow::Result<()> {
                 store,
                 index,
                 authn,
-                bindle::authz::always::AlwaysAuthorize,
+                bindle::authz::anonymous_get::AnonymousGet,
                 addr,
                 tls,
                 secret_store,
@@ -373,7 +373,7 @@ async fn main() -> anyhow::Result<()> {
                 store,
                 index,
                 authn,
-                bindle::authz::always::AlwaysAuthorize,
+                bindle::authz::anonymous_get::AnonymousGet,
                 addr,
                 tls,
                 secret_store,
@@ -392,7 +392,7 @@ async fn main() -> anyhow::Result<()> {
                 store,
                 index,
                 authn,
-                bindle::authz::always::AlwaysAuthorize,
+                bindle::authz::anonymous_get::AnonymousGet,
                 addr,
                 tls,
                 secret_store,

--- a/src/authz/always.rs
+++ b/src/authz/always.rs
@@ -8,7 +8,7 @@ pub struct Anonymous;
 
 impl Authorizable for Anonymous {
     fn principal(&self) -> String {
-        String::from("anonymous")
+        String::new()
     }
 
     fn groups(&self) -> Vec<String> {
@@ -25,7 +25,7 @@ impl Authorizer for AlwaysAuthorize {
         &self,
         _: A,
         _: &str,
-        _: warp::http::Method,
+        _: &warp::http::Method,
     ) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/authz/anonymous_get.rs
+++ b/src/authz/anonymous_get.rs
@@ -1,0 +1,28 @@
+//! An authorizer that authorizes anonymous access for GET requests and denies all other
+//! unauthenticated requests
+
+use warp::http::Method;
+
+#[derive(Clone)]
+pub struct AnonymousGet;
+
+impl super::Authorizer for AnonymousGet {
+    fn authorize<A: super::Authorizable>(
+        &self,
+        item: A,
+        _path: &str,
+        method: &Method,
+    ) -> anyhow::Result<()> {
+        // Any get request should succeed, no matter the path
+        if matches!(method, &Method::GET) {
+            return Ok(());
+        }
+
+        // An empty principal would mean this is anonymous
+        if item.principal().is_empty() {
+            anyhow::bail!("Anonymous authorization is not allowed for non-GET endpoints")
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/src/authz/mod.rs
+++ b/src/authz/mod.rs
@@ -2,6 +2,7 @@
 //! is enabled
 
 pub mod always;
+pub mod anonymous_get;
 
 /// A trait that can be implemented on any type (such as a custom `User` or `Token` type) so that it
 /// can be authorized by an [`Authorizer`](Authorizer)
@@ -24,6 +25,6 @@ pub trait Authorizer {
         &self,
         item: A,
         path: &str,
-        method: warp::http::Method,
+        method: &warp::http::Method,
     ) -> anyhow::Result<()>;
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,7 +6,10 @@ use bindle::client::{tokens::TokenManager, Client};
 use bindle::testing;
 
 const ENV_BINDLE_URL: &str = "BINDLE_URL";
+#[cfg(not(target_family = "windows"))]
 const BINARY_NAME: &str = "bindle-server";
+#[cfg(target_family = "windows")]
+const BINARY_NAME: &str = "bindle-server.exe";
 
 // Inserts data into the test server for fetching
 async fn setup_data<T: TokenManager>(client: &Client<T>) {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -10,7 +10,10 @@ use bindle::testing;
 
 use tokio_stream::StreamExt;
 
+#[cfg(not(target_family = "windows"))]
 const BINARY_NAME: &str = "bindle-server";
+#[cfg(target_family = "windows")]
+const BINARY_NAME: &str = "bindle-server.exe";
 
 #[tokio::test]
 async fn test_successful() {


### PR DESCRIPTION
The major change here is that now if no authorization header is passed
authentication will be "successful" and pass on anonymous auth instead.