### PR TITLE
fix(makefile): Adds missing info for flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TLS_OPTS ?= --tls-cert $(CERT_NAME).crt.pem --tls-key $(CERT_NAME).key.pem
 AUTH_MODE ?=
 # Example of HTTP basic auth with the testing fixture data. 
 #AUTH_MODE ?= --htpasswd-file test/data/htpasswd
-EMBEDDED_FLAG ?= --use-embedded-db
+EMBEDDED_FLAG ?= --use-embedded-db true
 
 export RUST_LOG=error,warp=info,bindle=$(BINDLE_LOG_LEVEL)
 


### PR DESCRIPTION
The change to make the embedded db flag take an optional now forces
you to pass an actual `bool` value to the flag