### PR TITLE
Clearer error on bad token file

### DIFF
--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -113,7 +113,10 @@ async fn run() -> std::result::Result<(), ClientError> {
                     PickYourAuth::None(NoToken)
                 }
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                let message = format!("Error loading token file {:?}: {}", &token_file, e);
+                return Err(ClientError::InvalidConfig(message));
+            }
         }
     } else {
         PickYourAuth::None(NoToken)


### PR DESCRIPTION
Previously if you had a bad token file (like, one left over from a previous go at Bindle auth) it gave you

```
Invalid TOML

Error trace:
        1: expected an equals, found eof at line 1 column 41
```

which didn't help you resolve it.

With this change it gives you:

```
Invalid configuration: Error loading token file "/home/ivan/.config/bindle/.token": Invalid TOML
```

which is hopefully enough to track down the problem and decide what you want to do about it.

Fixes #228.

