### PR TITLE
improve error messages for network connection failures

### DIFF
--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -58,7 +58,7 @@ pub enum ClientError {
         message: Option<String>,
     },
     /// A server error was encountered. Contains an optional message from the server
-    #[error("Server has encountered an error: {}", .0.clone().unwrap_or_else(||"Protocol error. Verify the Bindle URL".to_owned()))]
+    #[error("Error contacting server: {}", .0.clone().unwrap_or_else(||"Protocol error. Verify the Bindle URL".to_owned()))]
     ServerError(Option<String>),
     /// Invalid credentials were used or user does not have access to the requested resource. This
     /// is only valid if the server supports authentication and/or permissions

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -52,13 +52,13 @@ pub enum ClientError {
     ParcelAlreadyExists,
     /// The error returned when the request is invalid. Contains the underlying HTTP status code and
     /// any message returned from the API
-    #[error("Invalid request (status code {status_code:?}): {message:?}")]
+    #[error("Invalid request (status code {status_code:?}): {}", .message.clone().unwrap_or_else(|| "unknown error".to_owned()))]
     InvalidRequest {
         status_code: reqwest::StatusCode,
         message: Option<String>,
     },
     /// A server error was encountered. Contains an optional message from the server
-    #[error("Server has encountered an error: {0:?}")]
+    #[error("Server has encountered an error: {}", .0.clone().unwrap_or_else(||"Protocol error. Verify the Bindle URL".to_owned()))]
     ServerError(Option<String>),
     /// Invalid credentials were used or user does not have access to the requested resource. This
     /// is only valid if the server supports authentication and/or permissions

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -617,6 +617,10 @@ async fn unwrap_status(
         (StatusCode::CONFLICT, Endpoint::Invoice) => Err(ClientError::InvoiceAlreadyExists),
         (StatusCode::CONFLICT, Endpoint::Parcel) => Err(ClientError::ParcelAlreadyExists),
         (StatusCode::UNAUTHORIZED, _) => Err(ClientError::Unauthorized),
+        (StatusCode::BAD_REQUEST, _) => Err(ClientError::ServerError(Some(
+            "The request could not be handled by the server. Verify your Bindle server URL"
+                .to_owned(),
+        ))),
         // You can't range match on u16 so we use a guard
         (_, _) if resp.status().is_server_error() => {
             Err(ClientError::ServerError(parse_error_from_body(resp).await))


### PR DESCRIPTION
This traps networking errors and makes a noble effort to be informative.

Most, if not all, network errors will be due to either network failure or pointing at the wrong URL. This PR tries to catch those that result in hitting the wrong URL.

Server responds 400 BAD REQUEST:

```
$ bindle --server http://bindle.f1sh.ca:8080/v1 search
Server has encountered an error: The request could not be handled by the server. Verify your Bindle server URL
```

A networking error occurred during connection (e.g. wrong port, server disconnects abruptly):

```
$ bindle --server http://bindle.f1sh.ca/v1 search
Server has encountered an error: Protocol error. Verify the Bindle URL
```


Closes #231 

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>