### PR TITLE
Upgrade deps with `cargo upgrade`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "async-trait"
@@ -114,7 +114,7 @@ dependencies = [
  "rand 0.7.3",
  "reqwest",
  "rstest",
- "semver 0.11.0",
+ "semver",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
  "dirs-sys",
 ]
@@ -1219,15 +1219,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,7 +1530,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.4",
+ "semver",
 ]
 
 [[package]]
@@ -1624,27 +1615,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
 dependencies = [
- "pest",
+ "serde",
 ]
 
 [[package]]
@@ -1679,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1725,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -1779,9 +1754,9 @@ checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "sled"
-version = "0.34.6"
+version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0132f3e393bcb7390c60bb45769498cf4550bcb7a21d7f95c02b69f6362cdc"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
 dependencies = [
  "crc32fast",
  "crossbeam-epoch",
@@ -1884,18 +1859,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2015,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2044,9 +2019,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
 dependencies = [
  "cfg-if",
  "log",
@@ -2057,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2068,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
+checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
 dependencies = [
  "lazy_static",
 ]
@@ -2108,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
+checksum = "62af966210b88ad5776ee3ba12d5f35b8d6a2b2a12168f3080cf02b814d7376b"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -2167,12 +2142,6 @@ name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,50 +37,50 @@ cli = ["clap", "tracing-subscriber"]
 all-features = true
 
 [dependencies]
-anyhow = "1.0"
-toml = "0.5"
-serde = {version = "1.0", features = ["derive"]}
-serde_json = "1.0"
-tempfile = "3.2"
-sha2 = "0.9"
-thiserror = "1.0"
-semver = { version = "0.11", features = ["serde"] }
-tokio = { version = "1.0", features = ["full"] }
-tokio-util = { version = "0.6", features = ["io"] }
-tokio-stream = { version = "0.1", features = ["fs"] }
-warp = { version = "0.3", features = ["tls"], optional = true }
-bytes = "1.0"
-async-trait = "0.1"
-futures = "0.3"
+anyhow = "1.0.44"
+toml = "0.5.8"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
+tempfile = "3.2.0"
+sha2 = "0.9.8"
+thiserror = "1.0.29"
+semver = { version = "1.0.4", features = ["serde"] }
+tokio = { version = "1.11.0", features = ["full"] }
+tokio-util = { version = "0.6.8", features = ["io"] }
+tokio-stream = { version = "0.1.7", features = ["fs"] }
+warp = { version = "0.3.1", features = ["tls"], optional = true }
+bytes = "1.1.0"
+async-trait = "0.1.51"
+futures = "0.3.17"
 clap = { version = "3.0.0-beta.4", optional = true }
-reqwest = { version = "0.11", features = ["stream"] }
-hyper = "0.14"
-url = "2.2"
-tracing-subscriber = { version = "0.2", optional = true }
-dirs = { version = "3.0", optional = true }
-mime_guess = { version = "2.0", optional = true }
-lru = "0.6"
+reqwest = { version = "0.11.4", features = ["stream"] }
+hyper = "0.14.12"
+url = "2.2.2"
+tracing-subscriber = { version = "0.2.22", optional = true }
+dirs = { version = "4.0.0", optional = true }
+mime_guess = { version = "2.0.3", optional = true }
+lru = "0.6.6"
 # We need the older version of rand for dalek
 rand = "0.7"
-ed25519-dalek = "1.0"
-base64 = "0.13"
-tracing = { version = "0.1", features = ["log"] }
-tracing-futures = "0.2"
-mime = "0.3"
-sled = "0.34"
-serde_cbor = "0.11"
-oauth2 = {version = "4.1", features = ["reqwest"]}
-jsonwebtoken = "7.2"
-openid = {version = "0.9", optional = true}
-bcrypt = "0.10"
-chrono = { version = "0.4", features = ["serde"], optional = true }
-either = "1.6"
+ed25519-dalek = "1.0.1"
+base64 = "0.13.0"
+tracing = { version = "0.1.27", features = ["log"] }
+tracing-futures = "0.2.5"
+mime = "0.3.16"
+sled = "0.34.7"
+serde_cbor = "0.11.2"
+oauth2 = { version = "4.1.0", features = ["reqwest"] }
+jsonwebtoken = "7.2.0"
+openid = { version = "0.9.3", optional = true }
+bcrypt = "0.10.1"
+chrono = { version = "0.4.19", features = ["serde"], optional = true }
+either = "1.6.1"
 
 # NOTE: This is a workaround due to a dependency issue in oauth2: https://github.com/tkaitchuck/ahash/issues/95#issuecomment-903560879
 indexmap = "~1.6.2"
 
 [dev-dependencies]
-rstest = "0.11"
+rstest = "0.11.0"
 
 [[bin]]
 name = "bindle-server"


### PR DESCRIPTION
This commit upgrades bindle's deps with `cargo upgrade`.

For almost all the deps, this just sets the patch version to the latest available, thus treating it as the minimum patch level for the given major.minor.

This specifically upgrades the `semver` crate to latest, as bindle was using a very old version that prevents downstream crates from using a newer version. As a result, a code change was required to maintain "npm" compatibility (which is no longer a thing in the `semver` crate).

The `dirs` create is upgraded to `4.0` with this change (API compatible).

The `rand` dependency was not updated as an upstream dependency uses a
backwards incompatible version.