### PR TITLE
Add unauthenticated flag to bindle-server

### DIFF
--- a/bin/server.rs
+++ b/bin/server.rs
@@ -141,6 +141,14 @@ struct Opts {
         about = "The URL of the OIDC issuer your tokens should be issued by. This is used for verification of the token and for OIDC discovery"
     )]
     oidc_issuer_url: Option<String>,
+
+    #[clap(
+        name = "unauthenticated",
+        long = "unauthenticated",
+        about = "Run server in develepment mode"
+    )]
+    #[serde(default)]
+    unauthenticated: bool,
 }
 
 #[tokio::main]
@@ -273,8 +281,12 @@ async fn main() -> anyhow::Result<()> {
         )
     } else if let Some(htpasswd) = opts.htpasswd_file {
         AuthType::HttpBasic(htpasswd)
-    } else {
+    } else if opts.unauthenticated || config.unauthenticated {
         AuthType::None
+    } else {
+        anyhow::bail!(
+            "An authentication method must be specified.  Use --unauthenticated to run server without authentication"
+        );
     };
 
     // TODO: This is really gnarly, but the associated type on `Authenticator` makes turning it into

--- a/tests/standalone.rs
+++ b/tests/standalone.rs
@@ -172,6 +172,7 @@ async fn test_push() {
             "--bin",
             "bindle-server",
             "--",
+            "--unauthenticated",
             "-i",
             address,
             "-d",

--- a/tests/test_util.rs
+++ b/tests/test_util.rs
@@ -42,6 +42,7 @@ impl TestController {
                 .join(server_binary_name),
         )
         .args(&[
+            "--unauthenticated",
             "-d",
             tempdir.path().to_string_lossy().to_string().as_str(),
             "-i",


### PR DESCRIPTION
Makes running bindle-server without authentication an explicit option.

Closes: #235