### PR TITLE
Emit events for data changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
+dependencies = [
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +158,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -93,6 +210,7 @@ name = "bindle"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "async-std",
  "async-trait",
  "base64 0.13.0",
  "bcrypt",
@@ -164,6 +282,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "blowfish"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +333,12 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
@@ -269,6 +407,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +470,16 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -409,6 +566,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
+name = "fastrand"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -501,6 +673,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +774,19 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -839,6 +1039,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +1075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
+ "value-bag",
 ]
 
 [[package]]
@@ -1177,6 +1387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1471,19 @@ name = "pkg-config"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+
+[[package]]
+name = "polling"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2250,6 +2479,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9680608df133af2c1ddd5eaf1ddce91d60d61b6bc51494ef326458365a470a"
 
 [[package]]
+name = "value-bag"
+version = "1.0.0-alpha.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae"
+dependencies = [
+ "ctor",
+ "version_check",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,6 +2505,12 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"
@@ -2414,6 +2659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ openid = { version = "0.9.3", optional = true }
 bcrypt = "0.10.1"
 chrono = { version = "0.4.19", features = ["serde"], optional = true }
 either = "1.6.1"
+async-std = "1.9.0"
 
 # NOTE: This is a workaround due to a dependency issue in oauth2: https://github.com/tkaitchuck/ahash/issues/95#issuecomment-903560879
 indexmap = "~1.6.2"

--- a/docs/README.md
+++ b/docs/README.md
@@ -214,6 +214,29 @@ This file can be moved from system to system, just like OpenPGP or SSH key sets.
 - To create a signing key for a client, use `bindle create-key`
 - By default, if Bindle does not find an existing keyring, it creates one of these when it first starts.
 
+## Generating Change Events
+
+Starting bindle with the `--events`  flag will cause it to emit an record of the event to a file named `bindle-event.log` in the bindle data directory.
+
+Each event is serialized as a JSON object in the following format:
+``` json
+{
+  "event_date": "2021-10-05T20:05:51.028318270Z",
+  "event_data": {
+    "EventType": EventSpecificData
+  }
+}
+```
+
+The following event types are recorded:
+
+- **InvoiceCreated** - occurs when an invoice is created.
+- **MissingParcel** - occurs when an invoice is created, but a parcel is missing.
+- **ParcelCreated** - occurs when a parcel is created.
+- **InvoiceYanked** - occurs when an invoice is yanked.
+
+Examples of each event can be found [here](example-events.md).
+
 ## Specification
 
 1. The specification for the Bindle format and design begins with the [Bindle Specification](bindle-spec.md).

--- a/docs/example-events.md
+++ b/docs/example-events.md
@@ -1,0 +1,98 @@
+# Event Types
+
+These are examples of events that can be emitted when running bindle with the --events flag.
+
+## Invoice Created
+
+```json
+{
+  "event_date": "2021-10-05T20:05:50.997960746Z",
+  "event_data": {
+    "InvoiceCreated": {
+      "bindleVersion": "1.0.0",
+      "yanked": null,
+      "yankedSignature": null,
+      "bindle": {
+        "name": "enterprise.com/warpcore",
+        "version": "1.0.0",
+        "description": "Warp core components",
+        "authors": [
+          "Geordi La Forge <mycoolvisor@ufp.com>"
+        ]
+      },
+      "annotations": {
+        "engineering_location": "main"
+      },
+      "parcel": [
+        {
+          "label": {
+            "sha256": "23f310b54076878fd4c36f0c60ec92011a8b406349b98dd37d08577d17397de5",
+            "mediaType": "text/plain",
+            "name": "isolinear_chip.txt",
+            "size": 9,
+            "annotations": null,
+            "feature": null,
+            "origin": null
+          },
+          "conditions": null
+        }
+      ],
+      "group": null,
+      "signature": [
+        {
+          "by": "Test <test@example.com>",
+          "signature": "OxjhtGwTVDMJScoBDovNB1U52RsD2DyMgQoPIVAew0n4UKyY9Cw8S7KEkSsN6Lj71EFt8QPKO1hg1Tsz26MtBg==",
+          "key": "ccjHo+plTirpq+QJQ40/vrVjrVIycjMQeoDwdZZsbW8=",
+          "role": "host",
+          "at": 1633464350
+        }
+      ]
+    }
+  }
+}
+```
+
+## Missing Parcel
+
+```json
+{
+  "event_date": "2021-10-05T20:05:51.013871309Z",
+  "event_data": {
+    "MissingParcel": {
+      "sha256": "23f310b54076878fd4c36f0c60ec92011a8b406349b98dd37d08577d17397de5",
+      "mediaType": "text/plain",
+      "name": "isolinear_chip.txt",
+      "size": 9,
+      "annotations": null,
+      "feature": null,
+      "origin": null
+    }
+  }
+}
+```
+
+## ParcelCreated
+
+```json
+
+{
+  "event_date": "2021-10-05T20:05:51.028318270Z",
+  "event_data": {
+    "ParcelCreated": [
+      "enterprise.com/warpcore/1.0.0",
+      "23f310b54076878fd4c36f0c60ec92011a8b406349b98dd37d08577d17397de5"
+    ]
+  }
+}
+```
+
+## Invoice Yanked
+
+```json
+{
+  "event_date": "2021-10-05T20:05:51.028318270Z",
+  "event_data": {
+    "InvoiceYanked":"enterprise.com/warpcore/1.0.0"
+  }
+}
+```

--- a/src/events/defaultsink.rs
+++ b/src/events/defaultsink.rs
@@ -1,0 +1,25 @@
+use crate::events::{EventSink, EventType};
+use serde::Serialize;
+
+pub struct DefaultEventSink {}
+impl DefaultEventSink {
+    pub fn new() -> Self {
+        DefaultEventSink {}
+    }
+}
+
+impl Clone for DefaultEventSink {
+    fn clone(&self) -> Self {
+        DefaultEventSink {}
+    }
+}
+
+#[async_trait::async_trait]
+impl EventSink for DefaultEventSink {
+    async fn raise_event<T>(&self, _: EventType<T>) -> Result<(), Box<dyn std::error::Error>>
+    where
+        T: Serialize + Send + Sync,
+    {
+        Ok(())
+    }
+}

--- a/src/events/filesink.rs
+++ b/src/events/filesink.rs
@@ -1,0 +1,112 @@
+use async_std::fs::OpenOptions;
+use async_std::io::prelude::*;
+use serde::Serialize;
+use std::path::PathBuf;
+use tracing::info;
+
+use chrono::prelude::*;
+
+use crate::events::{EventSink, EventType};
+
+pub const EVENT_SINK_FILE_NAME: &str = "bindle_event.log";
+pub struct FileEventSink {
+    file: PathBuf,
+}
+
+impl FileEventSink {
+    pub fn new(directory: PathBuf) -> Self {
+        info!("Using FileEventSink");
+        Self {
+            file: directory.join(EVENT_SINK_FILE_NAME),
+        }
+    }
+}
+
+impl Clone for FileEventSink {
+    fn clone(&self) -> Self {
+        FileEventSink {
+            file: self.file.clone(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct EventLog<T> {
+    event_date: DateTime<Utc>,
+    event_data: EventType<T>,
+}
+
+#[async_trait::async_trait]
+impl EventSink for FileEventSink {
+    async fn raise_event<T>(&self, event: EventType<T>) -> Result<(), Box<dyn std::error::Error>>
+    where
+        T: Serialize + Send + Sync,
+    {
+        let data = EventLog {
+            event_date: Utc::now(),
+            event_data: event,
+        };
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.file)
+            .await?;
+        let mut buf = serde_json::to_vec_pretty(&data)?;
+        buf.push(b'\n');
+        file.write_all(&buf).await?;
+        file.flush().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+
+mod test {
+
+    use super::*;
+    use async_std::fs::File;
+    use tempfile::tempdir;
+
+    use crate::testing::{BindleEvent, InvoiceYankedEventData};
+
+    #[tokio::test]
+    async fn test_should_create_and_write_to_file() {
+        let temp = tempdir().expect("unable to create tempdir");
+        let directory = PathBuf::from(temp.path());
+        let filename = directory.join(EVENT_SINK_FILE_NAME);
+        let sink = FileEventSink::new(directory);
+        sink.raise_event(EventType::InvoiceYanked("test"))
+            .await
+            .unwrap();
+        let mut file = File::open(filename).await.unwrap();
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).await.unwrap();
+        let event: BindleEvent<InvoiceYankedEventData> = serde_json::from_str(&buf).unwrap();
+        assert_eq!("test", event.event_data.invoice_yanked);
+    }
+
+    #[tokio::test]
+    async fn test_should_create_and_append_to_a_file() {
+        let temp = tempdir().expect("unable to create tempdir");
+        let directory = PathBuf::from(temp.path());
+        let filename = directory.join(EVENT_SINK_FILE_NAME);
+        let sink = FileEventSink::new(directory);
+        sink.raise_event(EventType::InvoiceYanked("test0"))
+            .await
+            .unwrap();
+        sink.raise_event(EventType::InvoiceYanked("test1"))
+            .await
+            .unwrap();
+        let mut file = File::open(filename).await.unwrap();
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).await.unwrap();
+        let deserializer = serde_json::Deserializer::from_str(&buf);
+        let iterator = deserializer.into_iter::<serde_json::Value>();
+        for (i, event) in iterator.enumerate() {
+            let event: BindleEvent<InvoiceYankedEventData> =
+                serde_json::from_value(event.unwrap()).unwrap();
+            assert_eq!(format!("test{}", i), event.event_data.invoice_yanked);
+        }
+    }
+}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1,0 +1,54 @@
+//! Types and traits for use in emitting change notifications
+pub mod defaultsink;
+pub mod filesink;
+use super::events::defaultsink::DefaultEventSink;
+use super::events::filesink::FileEventSink;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub enum EventType<T> {
+    InvoiceCreated(T),
+    MissingParcel(T),
+    InvoiceYanked(T),
+    ParcelCreated(T),
+}
+
+#[async_trait::async_trait]
+pub trait EventSink {
+    // Emits an event.
+    async fn raise_event<T>(&self, _: EventType<T>) -> Result<(), Box<dyn std::error::Error>>
+    where
+        T: Serialize + Send + Sync;
+}
+
+// This enum exists to enable the type of event sync to be dynamically selected at runtime depending on arguments passed
+// to the program.
+// It seems like the normal approach of using trait objects does not work as the trait is not object safe as it has a generic type parameter.
+// parameter, this feels like a bit of a hack, but it's the only way I can see to do this.
+
+pub enum EventSyncs {
+    FileEventSink(FileEventSink),
+    DefaultEventSink(DefaultEventSink),
+}
+
+impl Clone for EventSyncs {
+    fn clone(&self) -> Self {
+        match self {
+            EventSyncs::FileEventSink(sink) => EventSyncs::FileEventSink(sink.clone()),
+            EventSyncs::DefaultEventSink(sink) => EventSyncs::DefaultEventSink(sink.clone()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl EventSink for EventSyncs {
+    async fn raise_event<T>(&self, event: EventType<T>) -> Result<(), Box<dyn std::error::Error>>
+    where
+        T: Serialize + Send + Sync,
+    {
+        match self {
+            EventSyncs::FileEventSink(sink) => sink.raise_event(event).await,
+            EventSyncs::DefaultEventSink(sink) => sink.raise_event(event).await,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod testing;
 pub mod authn;
 #[cfg(feature = "server")]
 pub mod authz;
+pub mod events;
 pub mod filters;
 
 #[doc(inline)]


### PR DESCRIPTION
closes #180 

This change enables bindle server to emit events describing changes that have occurred to the data it manages, the feature is enabled by running the server with the flag `--events`.  Enabling the feature causes bindle to serialize details of changes in JSON format to a file.

