### PR TITLE
chore(*): Bumps bindle to use the 2021 edition

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,13 +35,12 @@ jobs:
           OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
           echo "RUNNER_OS=$OS" >> $GITHUB_ENV
 
-      # hack: install rustfmt to work around darwin toolchain issues
-      - name: "(macOS) install dev tools"
-        if: runner.os == 'macOS'
-        run: |
-          rustup component add rustfmt --toolchain stable-x86_64-apple-darwin
-          rustup component add clippy --toolchain stable-x86_64-apple-darwin
-          rustup update stable
+      - name: Install latest Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          components: clippy, rustfmt
 
       - name: build release
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -21,6 +21,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install latest Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          components: clippy, rustfmt
       - name: Build
         run: make build
       - name: Run tests
@@ -46,6 +52,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install latest Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          components: clippy, rustfmt
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Matt Butcher <matt.butcher@microsoft.com>",
     "Taylor Thomas <taylor.thomas@microsoft.com>"
 ]
-edition = "2018"
+edition = "2021"
 license-file = "LICENSE.txt"
 description = "An aggregate object storage system for applications"
 repository = "https://github.com/deislabs/bindle"


### PR DESCRIPTION
We've been tracking and using most of the latest features anyway, so
this seems to make sense