### PR TITLE
fix(Makefile): add default value for BINDLE_DIRECTORY var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SERVER_FEATURES = --features cli
 SERVER_BIN := bindle-server
 CLIENT_FEATURES ?= --features=cli
 CLIENT_BIN := bindle
+BINDLE_DIRECTORY ?= ${HOME}/.bindle/bindles
 BINDLE_LOG_LEVEL ?= debug
 BINDLE_ID ?= enterprise.com/warpcore/1.0.0
 BINDLE_IFACE ?= 127.0.0.1:8080


### PR DESCRIPTION
I was following the steps in the README around [starting the server](https://github.com/deislabs/bindle#starting-the-server), specifically:

`If you would like to run the server with cargo run (useful when debugging), use make serve or make serve-tls. (The first time you run make serve-tls, it will prompt you to create a testing TLS cert.)`

When I ran `make serve`, I encountered the following error:

```
$ make serve
cargo run --features cli --bin bindle-server -- --directory  --address 127.0.0.1:8080   --unauthenticated
    Finished dev [unoptimized + debuginfo] target(s) in 0.52s
     Running `target/debug/bindle-server --directory --address '127.0.0.1:8080' --unauthenticated`
error: The argument '--directory <bindle_directory>' requires a value but none was supplied
```

Therefore, this PR proposes to add a default value in the Makefile for the BUNDLE_DIRECTORY var used in the command above (but currently empty due to no default being present).  Not sure the best value for the job; currently have it at `${HOME}/.bindle/bindles`, as this is a sample location mentioned in the [docs](https://github.com/deislabs/bindle/blob/main/docs/README.md#using-bindle).

Alternatively, we could update the referenced docs above to make it known that the user must set a value for this var before running the make target.