### PR TITLE
Adds codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @thomastaylor312 @technosophos @radu-matei


### PR DESCRIPTION
This will make it so we get auto assigned on reviews so we don't miss them among our other notifications (like I did 🤦 ). @technosophos and @bacongobbler I added both of you. If there are others who we need to add, please do so!