### PR TITLE
chore(Cargo.toml): bump tracing-subscriber dependency per #279

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "bindle"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -2162,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
+checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
 dependencies = [
  "ansi_term",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ clap = { version = "3", features = ["derive", "env", "cargo"], optional = true }
 reqwest = { version = "0.11.4", features = ["stream"] }
 hyper = "0.14.12"
 url = "2.2.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
+tracing-subscriber = { version = "0.3.7", features = ["env-filter"], optional = true }
 dirs = { version = "4.0.0", optional = true }
 mime_guess = { version = "2.0.3", optional = true }
 lru = "0.7"


### PR DESCRIPTION
* Bumps the tracing-subscriber dependency per https://github.com/deislabs/bindle/issues/279

I noticed that `cargo build` automagically bumped the bindle version via a patch increment to 0.7.1 -- handy!

Closes https://github.com/deislabs/bindle/issues/279