### PR TITLE
Fix for crate consumers not finding Signature trait methods

### DIFF
--- a/src/invoice/signature.rs
+++ b/src/invoice/signature.rs
@@ -204,7 +204,7 @@ impl KeyEntry {
             }
             Some(txt) => {
                 let decoded_txt = base64::decode(txt)?;
-                let sig = EdSignature::from_bytes(decoded_txt.as_slice())?;
+                let sig = EdSignature::try_from(decoded_txt.as_slice())?;
                 key.verify_strict(self.label.as_bytes(), &sig)?;
                 Ok(())
             }

--- a/src/invoice/verification.rs
+++ b/src/invoice/verification.rs
@@ -143,7 +143,7 @@ impl VerificationStrategy {
 
         let pubkey =
             PublicKey::from_bytes(&pk).map_err(|_| SignatureError::CorruptKey(sig.key.clone()))?;
-        let ed_sig = EdSignature::from_bytes(sig_block.as_slice())
+        let ed_sig = EdSignature::try_from(sig_block.as_slice())
             .map_err(|_| SignatureError::CorruptSignature(sig.key.clone()))?;
         pubkey
             .verify_strict(cleartext, &ed_sig)


### PR DESCRIPTION
This addresses an issue when consuming the `bindle` crate in WAGI (and, no doubt, other applications): the `ed25519_dalek::Signature::from_bytes`, used in `invoice/signature.rs` and `invoice/verification.rs`, method is actually on the `signature::Signature` trait which is not in scope in those files.  I don't yet understand why those files would compile in the Bindle client and server, but they don't compile in WAGI.  And adding the trait to the files makes them give an "unused import" warning in Bindle!

The fix is to instead use Signature's `TryFrom` implementation, which is documented in the Signature examples, doesn't need to be brought into scope, and delegates directly to `from_bytes` so shouldn't change any behaviour #famouslastwords.

@vdice would be great if you could give this a test please - I'm not sure how to exercise the signature stuff.  Thanks!