### PR TITLE
chore(Cargo.toml): bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "bindle"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bindle"
-version = "0.7.1"
+version = "0.8.0"
 authors = [
     "Matt Butcher <matt.butcher@microsoft.com>",
     "Taylor Thomas <taylor.thomas@microsoft.com>"

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ on Linux, MacOS, and Windows (in PowerShell):
 
 1. Download your desired version from [the releases
    page](https://github.com/deislabs/bindles/releases)
-1. Unpack it (`tar -xzf bindle-v0.7.1-linux-amd64.tar.gz`)
+1. Unpack it (`tar -xzf bindle-v0.8.0-linux-amd64.tar.gz`)
 1. Move the bindle and bindle CLIs to their desired
    destinations somewhere in your `$PATH` (e.g. `mv bindle bindle-server /usr/local/bin/` on Unix-like
    systems or `mv *.exe C:\Windows\system32\` on Windows)


### PR DESCRIPTION
* Bumps the version to the next minor release

This is more a 'suggestion to release'.  I'm not as up-to-speed on if we wanted to wait for certain features/changes before releasing 0.8.0 or not.  My motivation stems from https://github.com/deislabs/wagi needing the changes in #287 to succesfully rev its bindle version to the latest and greatest.

As it stands, this is the changelog since 0.7.1:

- chore(Cargo.toml): bump version to 0.8.0 c94e4aa7ff39cc415ca353e795510cc5b3f9e868 (Vaughn Dice)
- Fix for crate consumers not finding Signature trait methods (#287) d46c3715adc58882ea6e95d388dad3eebce57e54 (itowlson)
- fix(ci): Uses the correct var name 053cb8a65b471869f2ae379dbda2321b220a0df8 (Taylor Thomas)
- feat(ci): Adds support for m1 Macs and auto crate pushing f0dd36efa420fc75fd905c2d96cbb4147de3e767 (Taylor Thomas)
- feat(cli): Adds support for standalone tarballs to client 5a05dd24990b99a4a6b291e21bcdb63583f90864 (Taylor Thomas)
- feat(standalone): Adds tarball support to standalone bindles 3f3fbfc9f3e8387bdd5778af8319d2b0b7d56fbb (Taylor Thomas)
- fix(*): Fixes various clippy lints 2bc895b60569581ffacfff96ae0605ecd2fa7002 (Taylor Thomas)
- chore(Cargo.toml): bump tracing-subscriber dependency per #279 (#281) 3de704c8e66f50bb956938c6d63915149cf13ca1 (Vaughn Dice)
- docs(reference-spec.md): fix SemVer 2 link (#278) d2fcdbd1dbdd86a948728716bf522a27c3d7e16e (Vaughn Dice)
