### PR TITLE
feat(*): Adds required verification to the client

### DIFF
--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -1,3 +1,4 @@
+use bindle::VerificationStrategy;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -66,6 +67,13 @@ pub struct Opts {
         takes_value = false
     )]
     pub insecure: bool,
+
+    #[clap(
+        long = "strategy",
+        help = "The verification strategy to use when pulling the bindle",
+        default_value = "MultipleAttestationGreedy[Host]"
+    )]
+    pub strategy: VerificationStrategy,
 
     #[clap(subcommand)]
     pub subcmd: SubCommand,

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -9,7 +9,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let root = std::env::var("CARGO_MANIFEST_DIR")?;
     let root_path = std::path::PathBuf::from(root);
 
-    let bindle_client = client::Client::new(&url, client::tokens::NoToken)?;
+    let bindle_client = client::Client::new(
+        &url,
+        client::tokens::NoToken,
+        std::sync::Arc::new(bindle::signature::KeyRing::default()),
+    )?;
 
     // Load an invoice manually and send it to the server
     println!("Creating invoice 1");

--- a/src/cache/lru.rs
+++ b/src/cache/lru.rs
@@ -411,7 +411,7 @@ mod test {
         // Make sure all the create operations pass through
         let provider = TestProvider::default();
         let cache = LruCache::new(10, provider.clone());
-        let sk = SecretKeyEntry::new("TEST".to_owned(), vec![SignatureRole::Proxy]);
+        let sk = SecretKeyEntry::new("TEST", vec![SignatureRole::Proxy]);
 
         let scaffold = testing::Scaffold::load("valid_v1").await;
         let verified = VerificationStrategy::MultipleAttestation(vec![])

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -455,8 +455,8 @@ mod test {
             .expect("If no signature, then this should verify fine");
 
         // Create two signing keys.
-        let signer_name1 = "Matt Butcher <matt@example.com>".to_owned();
-        let signer_name2 = "Not Matt Butcher <not.matt@example.com>".to_owned();
+        let signer_name1 = "Matt Butcher <matt@example.com>";
+        let signer_name2 = "Not Matt Butcher <not.matt@example.com>";
 
         let keypair1 = SecretKeyEntry::new(signer_name1, vec![SignatureRole::Creator]);
         let keypair2 = SecretKeyEntry::new(signer_name2, vec![SignatureRole::Proxy]);

--- a/src/invoice/verification.rs
+++ b/src/invoice/verification.rs
@@ -271,7 +271,8 @@ impl VerificationStrategy {
     }
 }
 
-/// An invoice whose signatures have been verified. Can be converted borrowed as a plain [`Invoice`]
+/// An invoice whose signatures have been verified. Can be converted or borrowed as a plain
+/// [`Invoice`]
 pub struct VerifiedInvoice<T: Into<crate::Invoice>>(T);
 
 impl<T: Into<crate::Invoice>> Verified for VerifiedInvoice<T> {}
@@ -528,12 +529,10 @@ mod test {
         "#;
         let invoice: crate::Invoice = toml::from_str(invoice).expect("a nice clean parse");
 
-        let key_creator =
-            SecretKeyEntry::new("Test Creator".to_owned(), vec![SignatureRole::Creator]);
-        let key_approver =
-            SecretKeyEntry::new("Test Approver".to_owned(), vec![SignatureRole::Approver]);
-        let key_host = SecretKeyEntry::new("Test Host".to_owned(), vec![SignatureRole::Host]);
-        let key_proxy = SecretKeyEntry::new("Test Proxy".to_owned(), vec![SignatureRole::Proxy]);
+        let key_creator = SecretKeyEntry::new("Test Creator", vec![SignatureRole::Creator]);
+        let key_approver = SecretKeyEntry::new("Test Approver", vec![SignatureRole::Approver]);
+        let key_host = SecretKeyEntry::new("Test Host", vec![SignatureRole::Host]);
+        let key_proxy = SecretKeyEntry::new("Test Proxy", vec![SignatureRole::Proxy]);
         let keyring_keys = vec![
             key_approver.clone().try_into().expect("convert to pubkey"),
             key_host.clone().try_into().expect("convert to pubkey"),
@@ -675,8 +674,7 @@ mod test {
                 .expect("signed as creator");
 
             // Mock an unknown key and don't add it to keyring
-            let key_anon =
-                SecretKeyEntry::new("Unknown key".to_owned(), vec![SignatureRole::Approver]);
+            let key_anon = SecretKeyEntry::new("Unknown key", vec![SignatureRole::Approver]);
             inv.sign(SignatureRole::Approver, &key_anon)
                 .expect("signed with unknown key");
 

--- a/src/provider/file/mod.rs
+++ b/src/provider/file/mod.rs
@@ -670,7 +670,7 @@ mod test {
 
     fn mock_secret_key() -> SecretKeyEntry {
         SecretKeyEntry::new(
-            "Bogo Key".to_owned(),
+            "Bogo Key",
             vec![
                 SignatureRole::Host,
                 SignatureRole::Proxy,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -302,7 +302,7 @@ mod test {
             KeyRing::default(),
         );
 
-        let sk = SecretKeyEntry::new("test".to_owned(), vec![SignatureRole::Host]);
+        let sk = SecretKeyEntry::new("test", vec![SignatureRole::Host]);
 
         // Insert an invoice
         let scaffold = testing::Scaffold::load("incomplete").await;
@@ -380,7 +380,7 @@ mod test {
         );
         let valid_raw = bindles.get("valid_v1").expect("Missing scaffold");
         let valid = testing::Scaffold::from(valid_raw.clone());
-        let sk = SecretKeyEntry::new("test".to_owned(), vec![SignatureRole::Host]);
+        let sk = SecretKeyEntry::new("test", vec![SignatureRole::Host]);
         let verified = VerificationStrategy::MultipleAttestation(vec![])
             .verify(valid.invoice.clone(), &KeyRing::default())
             .unwrap();
@@ -432,7 +432,7 @@ mod test {
         let scaffold = testing::Scaffold::load("valid_v1").await;
         let parcel = scaffold.parcel_files.get("parcel").expect("Missing parcel");
         let data = std::io::Cursor::new(parcel.data.clone());
-        let sk = SecretKeyEntry::new("test".to_owned(), vec![SignatureRole::Host]);
+        let sk = SecretKeyEntry::new("test", vec![SignatureRole::Host]);
         let verified = VerificationStrategy::MultipleAttestation(vec![])
             .verify(scaffold.invoice.clone(), &KeyRing::default())
             .unwrap();
@@ -469,7 +469,7 @@ mod test {
 
         let scaffold = testing::Scaffold::load("invalid").await;
 
-        let sk = SecretKeyEntry::new("test".to_owned(), vec![SignatureRole::Host]);
+        let sk = SecretKeyEntry::new("test", vec![SignatureRole::Host]);
         let verified = VerificationStrategy::MultipleAttestation(vec![])
             .verify(scaffold.invoice.clone(), &KeyRing::default())
             .unwrap();
@@ -528,7 +528,7 @@ mod test {
         );
         let bindles_to_insert = vec!["incomplete", "valid_v1", "valid_v2"];
 
-        let sk = SecretKeyEntry::new("test".to_owned(), vec![SignatureRole::Host]);
+        let sk = SecretKeyEntry::new("test", vec![SignatureRole::Host]);
 
         for b in bindles_to_insert.into_iter() {
             let current = testing::Scaffold::load(b).await;
@@ -642,7 +642,7 @@ mod test {
         );
 
         let scaffold = testing::Scaffold::load("lotsa_parcels").await;
-        let sk = SecretKeyEntry::new("test".to_owned(), vec![SignatureRole::Host]);
+        let sk = SecretKeyEntry::new("test", vec![SignatureRole::Host]);
         let verified = VerificationStrategy::MultipleAttestation(vec![])
             .verify(scaffold.invoice.clone(), &KeyRing::default())
             .unwrap();

--- a/src/standalone/mod.rs
+++ b/src/standalone/mod.rs
@@ -227,7 +227,10 @@ async fn create_or_get_invoice<T: TokenManager>(
             } else {
                 Some(missing)
             };
-            Ok(crate::InvoiceCreateResponse { invoice, missing })
+            Ok(crate::InvoiceCreateResponse {
+                invoice: invoice.into(),
+                missing,
+            })
         }
         Err(e) => Err(e),
     }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -255,7 +255,7 @@ impl Default for MockKeyStore {
     fn default() -> Self {
         MockKeyStore {
             mock_secret_key: SecretKeyEntry::new(
-                "Test <test@example.com>".to_owned(),
+                "Test <test@example.com>",
                 vec![SignatureRole::Host],
             ),
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -150,6 +150,7 @@ async fn test_get() {
             "enterprise.com/warpcore/1.0.0",
         ])
         .env(ENV_BINDLE_URL, &controller.base_url)
+        .env(ENV_BINDLE_KEYRING, &controller.keyring_path)
         .output()
         .expect("Should be able to run command");
 
@@ -170,6 +171,7 @@ async fn test_get() {
             "enterprise.com/warpcore/1.0.0",
         ])
         .env(ENV_BINDLE_URL, &controller.base_url)
+        .env(ENV_BINDLE_KEYRING, &controller.keyring_path)
         .output()
         .expect("Should be able to run command");
 
@@ -193,6 +195,7 @@ async fn test_get() {
             "enterprise.com/warpcore/1.0.0",
         ])
         .env(ENV_BINDLE_URL, &controller.base_url)
+        .env(ENV_BINDLE_KEYRING, &controller.keyring_path)
         .output()
         .expect("Should be able to run command");
 
@@ -233,6 +236,7 @@ async fn test_get_invoice() {
             "enterprise.com/warpcore/1.0.0",
         ])
         .env(ENV_BINDLE_URL, &controller.base_url)
+        .env(ENV_BINDLE_KEYRING, &controller.keyring_path)
         .output()
         .expect("Should be able to run command");
 

--- a/tests/standalone.rs
+++ b/tests/standalone.rs
@@ -159,10 +159,7 @@ async fn test_push() {
         .await
         .expect("Should be able to read standalone bindle");
 
-    let client = bindle::client::Client::new(&controller.base_url, bindle::client::tokens::NoToken)
-        .expect("Invalid client config");
-
-    read.push(&client)
+    read.push(&controller.client)
         .await
         .expect("Should be able to push successfully");
 
@@ -181,10 +178,7 @@ async fn test_push_tarball() {
         .await
         .expect("Should be able to read standalone bindle");
 
-    let client = bindle::client::Client::new(&controller.base_url, bindle::client::tokens::NoToken)
-        .expect("Invalid client config");
-
-    read.push(&client)
+    read.push(&controller.client)
         .await
         .expect("Should be able to push successfully");
 


### PR DESCRIPTION
The default strategy is just to check that the host signature is valid, so
this shouldn't provide too much of a burden for people kicking the tires