### PR TITLE
ref(cli): Makes global bindle URL less annoying to work with

### DIFF
--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -16,7 +16,8 @@ pub struct Opts {
         short = 's',
         long = "server",
         env = "BINDLE_URL",
-        help = "The address of the bindle server. For the default local server, this should be http://localhost:8080/v1"
+        help = "The address of the bindle server, including the top level subpath (e.g. https://my.bindle.com/v1/",
+        default_value = "http://localhost:8080/v1/"
     )]
     pub server_url: String,
     #[clap(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -261,7 +261,6 @@ async fn test_create_key_and_sign_invoice() {
         );
         let output = std::process::Command::new("cargo")
             .args(cmd.split(' '))
-            .env(ENV_BINDLE_URL, "localhost:8080")
             .output()
             .expect("Key should get created");
         assert_status(output, "Key should be generated");
@@ -282,7 +281,6 @@ async fn test_create_key_and_sign_invoice() {
         );
         let output = std::process::Command::new("cargo")
             .args(cmd.split(' '))
-            .env(ENV_BINDLE_URL, "localhost:8080")
             .output()
             .expect("Invoice should get signed");
         assert_status(output, "Invoice should get signed");
@@ -535,7 +533,6 @@ async fn test_keyring_add() {
             "approver",
             "XbhLeOX4BtvUnT+o7xyi2waw5WXGOl3H/l3b5h97Dk4=",
         ])
-        .env(ENV_BINDLE_URL, "http://localhost:8080/v1")
         .env(ENV_BINDLE_KEYRING, &keyring_file)
         .output()
         .expect("Should be able to run command");
@@ -590,7 +587,6 @@ async fn test_keyring_add_to_existing() {
             "approver",
             "XbhLeOX4BtvUnT+o7xyi2waw5WXGOl3H/l3b5h97Dk4=",
         ])
-        .env(ENV_BINDLE_URL, "http://localhost:8080/v1")
         .env(ENV_BINDLE_KEYRING, &keyring_file)
         .output()
         .expect("Should be able to run command");
@@ -638,7 +634,6 @@ fn create_key(
     args.push(label);
     let output = std::process::Command::new("cargo")
         .args(args)
-        .env(ENV_BINDLE_URL, "http://localhost:8080/v1")
         .env(ENV_BINDLE_KEYRING, keyring_file)
         .output()
         .expect("Should be able to run command");


### PR DESCRIPTION
I just went with the simple workaround of providing a default. It results in
the least amount of code changes and is easy to override with your own value

Closes #111