### PR TITLE
fix(file): Adds error log when IO errors occur on invoice/parcel create

### DIFF
--- a/src/provider/file/mod.rs
+++ b/src/provider/file/mod.rs
@@ -179,7 +179,10 @@ impl<T: crate::search::Search + Send + Sync> Provider for FileProvider<T> {
                 return Err(ProviderError::Exists);
             }
             trace!(path = %inv_path.display(), "Base path doesn't exist, creating");
-            create_dir_all(inv_path).await?;
+            if let Err(e) = create_dir_all(inv_path).await {
+                error!(error = %e, "Unable to create invoice storage directory");
+                return Err(e.into());
+            }
         }
 
         // Open the destination or error out if it already exists.
@@ -349,7 +352,10 @@ impl<T: crate::search::Search + Send + Sync> Provider for FileProvider<T> {
         }
         // Create box dir
         trace!(path = %par_path.display(), "Creating parcel directory");
-        create_dir_all(par_path).await?;
+        if let Err(e) = create_dir_all(par_path).await {
+            error!(error = %e, "Unable to create parcel storage directory");
+            return Err(e.into());
+        }
 
         // Write data
         let mut part = PartFile::new(self.parcel_data_path(parcel_id)).await?;


### PR DESCRIPTION
This will now log an error when the bindle server initially tries to create
directories for invoices or parcels. I checked the embedded provider and these
kind of errors are caught on creation

Closes #297