### PR TITLE
feat(cli): add `bindle clean` subcommand to clear the local cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "oauth2",
  "openid",
  "rand 0.7.3",
+ "remove_dir_all 0.7.0",
  "reqwest",
  "rstest",
  "semver",
@@ -324,6 +325,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1476,6 +1498,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,6 +1573,19 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40"
+dependencies = [
+ "libc",
+ "log",
+ "num_cpus",
+ "rayon",
  "winapi",
 ]
 
@@ -1953,7 +2013,7 @@ dependencies = [
  "fastrand",
  "libc",
  "redox_syscall",
- "remove_dir_all",
+ "remove_dir_all 0.5.3",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,9 @@ tokio-tar = "0.3"
 # NOTE: This is a workaround due to a dependency issue in oauth2: https://github.com/tkaitchuck/ahash/issues/95#issuecomment-903560879
 indexmap = "~1.6.2"
 
+[target.'cfg(target_family = "windows")'.dependencies]
+remove_dir_all = "0.7.0"
+
 [dev-dependencies]
 rstest = "0.12.0"
 

--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -145,7 +145,7 @@ async fn run() -> std::result::Result<(), ClientError> {
         .build(&opts.server_url, token, keyring)?;
 
     let local = bindle::provider::file::FileProvider::new(
-        bindle_dir.clone(),
+        &bindle_dir,
         bindle::search::NoopEngine::default(),
     )
     .await;
@@ -435,8 +435,17 @@ async fn run() -> std::result::Result<(), ClientError> {
         }
         SubCommand::Clean(_clean_opts) => {
             // Cleans up the local bindles directory.
-            println!("Cleaning up bindles in {:?}...",bindle_dir);
-            tokio::fs::remove_dir_all(bindle_dir).await?;
+            println!("Cleaning up bindles in {}...", bindle_dir.display());
+
+            // although remove_dir_all crate could default to std::fs::remove_dir_all for unix family,
+            // we still prefer tokio::fs implementation for unix
+            #[cfg(target_family = "windows")]
+            tokio::task::spawn_blocking(|| remove_dir_all::remove_dir_all(bindle_dir))
+                .await
+                .map_err(|e| ClientError::Other(e.to_string()))??;
+
+            #[cfg(target_family = "unix")]
+            tokio::fs::remove_dir_all(bindle_dir.clone()).await?;
             println!("Clean up successful");
         }
     }

--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -145,7 +145,7 @@ async fn run() -> std::result::Result<(), ClientError> {
         .build(&opts.server_url, token, keyring)?;
 
     let local = bindle::provider::file::FileProvider::new(
-        bindle_dir,
+        bindle_dir.clone(),
         bindle::search::NoopEngine::default(),
     )
     .await;
@@ -432,6 +432,12 @@ async fn run() -> std::result::Result<(), ClientError> {
                     println!("Wrote key to keyring file at {}", keyring_path.display())
                 }
             }
+        }
+        SubCommand::Clean(_clean_opts) => {
+            // Cleans up the local bindles directory.
+            println!("Cleaning up bindles in {:?}...",bindle_dir);
+            tokio::fs::remove_dir_all(bindle_dir).await?;
+            println!("Clean up successful");
         }
     }
 

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -132,10 +132,7 @@ pub enum SubCommand {
         about = "Packages up a standalone bindle directory into a tarball"
     )]
     Package(Package),
-    #[clap(
-        name="clean",
-        about = "Cleans up the DumpCache bindles"
-    )]
+    #[clap(name = "clean", about = "Cleans up the DumpCache bindles")]
     Clean(Clean),
     #[clap(subcommand)]
     Keys(Keys),
@@ -522,4 +519,4 @@ pub struct Package {
 }
 
 #[derive(Parser)]
-pub struct  Clean {}
+pub struct Clean {}

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -132,7 +132,11 @@ pub enum SubCommand {
         about = "Packages up a standalone bindle directory into a tarball"
     )]
     Package(Package),
-
+    #[clap(
+        name="clean",
+        about = "Cleans up the DumpCache bindles"
+    )]
+    Clean(Clean),
     #[clap(subcommand)]
     Keys(Keys),
 }
@@ -516,3 +520,6 @@ pub struct Package {
     )]
     pub export_dir: PathBuf,
 }
+
+#[derive(Parser)]
+pub struct  Clean {}


### PR DESCRIPTION
fixes #280 
This PR adds `clean` subcommand to `bindle cli` to clear the DumpCache