### PR TITLE
ref(*): Better organizes features and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bcrypt"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f691e63585950d8c1c43644d11bab9073e40f5060dd2822734ae7c3dc69a3a80"
+checksum = "c8d70a6d9cd7179c1020c7f48512203ffe48cd1a442359e5f81881bf2cc165ac"
 dependencies = [
  "base64",
  "blowfish",
@@ -190,13 +190,12 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3ff3fc1de48c1ac2e3341c4df38b0d1bfb8fdf04632a187c8b75aaa319a7ab"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
  "cipher",
- "opaque-debug",
 ]
 
 [[package]]
@@ -255,11 +254,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -351,11 +351,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -850,6 +851,15 @@ checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown 0.9.1",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1f03d4ab4d5dc9ec2d219f86c15d2a15fc08239d1cd3b2d6a19717c0a2f443"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,13 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["server", "client", "caching", "test-tools"]
-server = ["warp", "openid"]
-client = ["mime_guess", "dirs", "time"]
-caching = []
+server = ["warp", "openid", "hyper", "mime", "either", "_common"]
+client = ["mime_guess", "dirs", "time", "async-compression", "tokio-tar", "_common"]
+# Internal use only feature that groups all of the optional deps we need for both server and client
+_common = ["providers", "tokio/full", "tokio-util", "oauth2", "reqwest"]
+# Activates provider implementations
+providers = ["lru", "serde_cbor", "sled"]
+caching = ["lru"]
 test-tools = []
 cli = ["clap", "tracing-subscriber", "atty"]
 
@@ -38,46 +42,46 @@ all-features = true
 
 [dependencies]
 anyhow = "1.0.44"
-toml = "0.5.8"
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.68"
-tempfile = "3.2.0"
-sha2 = "0.10"
-thiserror = "1.0.29"
-semver = { version = "1.0.4", features = ["serde"] }
-tokio = { version = "1.11.0", features = ["full"] }
-tokio-util = { version = "0.6.8", features = ["io"] }
-tokio-stream = { version = "0.1.7", features = ["fs"] }
-warp = { version = "0.3", features = ["tls"], optional = true }
-bytes = "1.1.0"
+async-compression = { version = "0.3", default-features = false, features = ["tokio", "gzip"], optional = true }
 async-trait = "0.1.51"
-futures = "0.3.17"
+atty = { version = "0.2", optional = true }
+base64 = "0.13.0"
+bcrypt = "0.11"
+bytes = "1.1.0"
 clap = { version = "3", features = ["derive", "env", "cargo"], optional = true }
-reqwest = { version = "0.11.4", features = ["stream"] }
-hyper = "0.14.12"
-url = "2.2.2"
-tracing-subscriber = { version = "0.3.7", features = ["env-filter"], optional = true }
 dirs = { version = "4.0.0", optional = true }
+ed25519-dalek = "1.0.1"
+either = { version = "1.6.1", optional = true }
+futures = "0.3.17"
+hyper = { version = "0.14.12", optional = true }
+jsonwebtoken = "8.0.0-beta.6"
+lru = { version = "0.7", optional = true }
+mime = { version = "0.3.16", optional = true }
 mime_guess = { version = "2.0.3", optional = true }
-lru = "0.7"
+oauth2 = { version = "4.1.0", features = ["reqwest"], optional = true }
+openid = { version = "0.9.3", optional = true }
 # We need the older version of rand for dalek
 rand = "0.7"
-ed25519-dalek = "1.0.1"
-base64 = "0.13.0"
+reqwest = { version = "0.11.4", features = ["stream"], optional = true }
+semver = { version = "1.0.4", features = ["serde"] }
+serde = { version = "1.0.130", features = ["derive"] }
+serde_cbor = { version = "0.11.2", optional = true }
+serde_json = "1.0.68"
+sha2 = "0.10"
+sled = { version = "0.34.7", optional = true }
+tempfile = "3.2.0"
+thiserror = "1.0.29"
+time = { version = "0.3", features = ["serde"], optional = true }
+tokio = { version = "1.11.0", default-features = false, features = ["fs", "sync", "io-util"] }
+tokio-stream = { version = "0.1.7", features = ["fs"] }
+tokio-tar = { version = "0.3", optional = true }
+tokio-util = { version = "0.6.8", features = ["io"], optional = true }
+toml = "0.5.8"
 tracing = { version = "0.1.27", features = ["log"] }
 tracing-futures = "0.2.5"
-mime = "0.3.16"
-sled = "0.34.7"
-serde_cbor = "0.11.2"
-oauth2 = { version = "4.1.0", features = ["reqwest"] }
-jsonwebtoken = "8.0.0-beta.6"
-openid = { version = "0.9.3", optional = true }
-bcrypt = "0.10.1"
-either = "1.6.1"
-time = { version = "0.3", features = ["serde"], optional = true }
-atty = {version = "0.2", optional = true}
-async-compression = { version = "0.3", default-features = false, features = ["tokio", "gzip"]}
-tokio-tar = "0.3"
+tracing-subscriber = { version = "0.3.7", features = ["env-filter"], optional = true }
+url = "2.2.2"
+warp = { version = "0.3", features = ["tls"], optional = true }
 
 # NOTE: This is a workaround due to a dependency issue in oauth2: https://github.com/tkaitchuck/ahash/issues/95#issuecomment-903560879
 indexmap = "~1.6.2"

--- a/src/invoice/api.rs
+++ b/src/invoice/api.rs
@@ -73,4 +73,5 @@ pub(crate) struct DeviceAuthorizationExtraFields {
     pub token_url: String,
 }
 
+#[cfg(any(feature = "client", feature = "server"))]
 impl oauth2::devicecode::ExtraDeviceAuthorizationFields for DeviceAuthorizationExtraFields {}

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -11,8 +11,12 @@ mod sealed;
 pub mod signature;
 pub mod verification;
 
+#[cfg(feature = "client")]
 #[doc(inline)]
-pub(crate) use api::{DeviceAuthorizationExtraFields, LoginParams};
+pub(crate) use api::DeviceAuthorizationExtraFields;
+#[cfg(any(feature = "client", feature = "server"))]
+#[doc(inline)]
+pub(crate) use api::LoginParams;
 #[doc(inline)]
 pub use api::{ErrorResponse, InvoiceCreateResponse, MissingParcelsResponse, QueryOptions};
 #[doc(inline)]

--- a/src/provider/embedded.rs
+++ b/src/provider/embedded.rs
@@ -8,6 +8,8 @@
 //!
 //! This provider is currently experimental, with the goal of replacing the `FileProvider` as the
 //! default provider in the future.
+//!
+//! This will only be available if the `provider` feature is enabled
 
 use std::convert::TryInto;
 use std::path::Path;

--- a/src/provider/file/mod.rs
+++ b/src/provider/file/mod.rs
@@ -1,6 +1,10 @@
-//! A file system `Storage` implementation. The format on disk is
+//! A file system `Provider` implementation.
+//!
+//! The format on disk is
 //! [documented](https://github.com/deislabs/bindle/blob/master/docs/file-layout.md) in the main
 //! Bindle repo.
+//!
+//! This will only be available if the `provider` feature is enabled
 
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -21,7 +21,9 @@
 //! will generally contain another Provider implementation or an HTTP client to talk to another
 //! server upstream
 
+#[cfg(feature = "providers")]
 pub mod embedded;
+#[cfg(feature = "providers")]
 pub mod file;
 
 use std::convert::TryInto;
@@ -208,6 +210,7 @@ impl From<std::convert::Infallible> for ProviderError {
 // TODO(thomastaylor312): We should probably have a more generic form of
 // deserialization/serialization errors that aren't tied to TOML as backends can serialize how they
 // want. For now there is this workaround
+#[cfg(feature = "providers")]
 impl From<serde_cbor::Error> for ProviderError {
     fn from(e: serde_cbor::Error) -> Self {
         if e.is_io() {


### PR DESCRIPTION
Sometimes a dependent project may need just the types, so now when
no features are enabled, just the core types and traits are exposed.

This also takes a first pass at "optionalizing" as many dependencies
as possible. The dependency tree has gotten quite large, so this tries
to only import things when they are absolutely needed. We could probably
add a few more features (like on the auth stuff) to make it perfect, but
this was a good start