### PR TITLE
Remove pinned indexmap dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,6 @@ dependencies = [
  "either",
  "futures",
  "hyper",
- "indexmap",
  "jsonwebtoken",
  "lru",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,6 @@ tracing-subscriber = { version = "0.3.7", features = ["env-filter"], optional = 
 url = "2.2.2"
 warp = { version = "0.3", features = ["tls"], optional = true }
 
-# NOTE: This is a workaround due to a dependency issue in oauth2: https://github.com/tkaitchuck/ahash/issues/95#issuecomment-903560879
-indexmap = "~1.6.2"
-
 [target.'cfg(target_family = "windows")'.dependencies]
 remove_dir_all = "0.7.0"
 


### PR DESCRIPTION
I couldn't figure out exactly what was originally breaking that needed this workaround, but bindle seems to build fine now without it.

This pinned version was breaking when trying to link with `toml_edit` in spin due to a version constraint incompatibility.