### PR TITLE
feat - add label search argument to sign-invoice

### DIFF
--- a/bin/client/main.rs
+++ b/bin/client/main.rs
@@ -324,7 +324,7 @@ async fn run() -> std::result::Result<(), ClientError> {
                         .await
                         .map_err(|e| ClientError::Other(e.to_string()))?;
 
-                    let matches: Vec<KeyEntry> = match print_key_opts.label {
+                    let matches: Vec<KeyEntry> = match print_key_opts.label_matching {
                         Some(name) => keyfile
                             .key
                             .iter()

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -419,12 +419,11 @@ pub struct PrintKey {
     )]
     pub secret_file: Option<PathBuf>,
     #[clap(
-        short = 'l',
-        long = "label",
-        value_name = "LABEL",
-        help = "The label to search for. If supplied, this will return each key that contains this string in its label. For example, '--label=ample' will match 'label: Examples'."
+        short = 'm',
+        long = "label-matching",
+        help = "selects the keys that (partially) matches the given label. If supplied, this will return each key that contains this string in its label. For example, '--label=ample' will match 'label: Examples'."
     )]
-    pub label: Option<String>,
+    pub label_matching: Option<String>,
 }
 
 #[derive(Parser)]

--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -448,6 +448,19 @@ pub struct SignInvoice {
     )]
     pub role: Option<String>,
     #[clap(
+        short = 'l',
+        long = "label",
+        conflicts_with = "label-matching",
+        help = "selects the key with the exact given label"
+    )]
+    pub label: Option<String>,
+    #[clap(
+        short = 'm',
+        long = "label-matching",
+        help = "selects the key that (partially) matches the given label. If supplied, this will sign with the key that contains this string in its label. For example, '--label=ample' will match 'label: Examples'."
+    )]
+    pub label_matching: Option<String>,
+    #[clap(
         short = 'o',
         long = "out",
         help = "the location to write the modified invoice. By default, it will write to invoice-HASH.toml, where HASH is computed on name and version"

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -74,7 +74,7 @@ pub mod v1 {
         // with my private key, and THEN go on to store.create_invoice()
 
         let role = SignatureRole::Host;
-        let sk = match secret_store.get_first_matching(&role) {
+        let sk = match secret_store.get_first_matching(&role, None) {
             None => {
                 return Ok(reply::into_reply(ProviderError::FailedSigning(
                     SignatureError::NoSuitableKey,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -187,7 +187,7 @@ mod test {
             SignatureRole::Creator,
             valid_v1
                 .keys
-                .get_first_matching(&SignatureRole::Creator)
+                .get_first_matching(&SignatureRole::Creator, None)
                 .unwrap(),
         )
         .unwrap();

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -17,7 +17,7 @@ use crate::invoice::signature::{
 use crate::provider::embedded::EmbeddedProvider;
 use crate::provider::file::FileProvider;
 use crate::search::StrictEngine;
-use crate::signature::KeyRingLoader;
+use crate::signature::{KeyRingLoader, LabelMatch};
 
 use sha2::{Digest, Sha256};
 use tempfile::tempdir;
@@ -296,7 +296,11 @@ impl Default for MockKeyStore {
 }
 
 impl SecretKeyStorage for MockKeyStore {
-    fn get_first_matching(&self, _role: &SignatureRole) -> Option<&SecretKeyEntry> {
+    fn get_first_matching(
+        &self,
+        _role: &SignatureRole,
+        _match_type: Option<&LabelMatch>,
+    ) -> Option<&SecretKeyEntry> {
         Some(&self.mock_secret_key)
     }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -170,7 +170,7 @@ async fn test_already_created() {
             SignatureRole::Creator,
             scaffold
                 .keys
-                .get_first_matching(&SignatureRole::Creator)
+                .get_first_matching(&SignatureRole::Creator, None)
                 .unwrap(),
         )
         .unwrap();


### PR DESCRIPTION
fixes #299

this PR adds optional ability to `sign-invoice` with a key that matches the given label

 ### For example
#### `--label-matching` (partial match)
```
❯ bindle sign-invoice -o signed-invoice.toml invoice.toml --label-matching "Vishnu Jin"
Signed invoice.toml with role creator, label as 'Vishnu Jin <vishnujin@outlook.com>' and wrote to signed-invoice.toml
```

#### `--label ` (exact match)
```
❯ bindle sign-invoice -o signed-invoice.toml invoice.toml --label "Vishnu Jin <vishnujin@outlook.com>"
Signed invoice.toml with role creator, label as 'Vishnu Jin <vishnujin@outlook.com>' and wrote to signed-invoice.toml
```
