### PR TITLE
Fix: head method not allowed for query `_q` path

### DIFF
--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -121,7 +121,7 @@ pub mod v1 {
             S: Search + Clone + Send + Sync,
         {
             warp::path("_q")
-                .and(warp::get())
+                .and(warp::get().or(warp::head()).unify())
                 .and(warp::query::<crate::QueryOptions>())
                 .and(warp::any().map(move || index.clone()))
                 .and(warp::header::optional::<String>("accept"))


### PR DESCRIPTION
fixes #331 


#### after fix 
```
❯ curl http://localhost:8080/v1/_q\?q\=mybind -I                            
HTTP/1.1 200 OK
content-type: application/toml
content-length: 804
date: Thu, 14 Apr 2022 20:51:19 GMT
```