### PR TITLE
feat(*): Adds bindle-keys endpoint support

### DIFF
--- a/bin/client/opts.rs
+++ b/bin/client/opts.rs
@@ -153,7 +153,8 @@ pub enum Keys {
         about = "Print the public key entries for keys from the secret key file. If no '--label' is supplied, public keys for all secret keys are returned."
     )]
     Print(PrintKey),
-    // TODO(thomastaylor312): We should probably add an endpoint to bindle servers that allow you to download a host key and add a subcommand to help with it
+    #[clap(name = "fetch", about = "Fetch keys from a /bindle-keys endpoint")]
+    Fetch(FetchKeys),
 }
 
 #[derive(Parser)]
@@ -424,6 +425,25 @@ pub struct PrintKey {
         help = "selects the keys that (partially) matches the given label. If supplied, this will return each key that contains this string in its label. For example, '--label=ample' will match 'label: Examples'."
     )]
     pub label_matching: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct FetchKeys {
+    #[clap(
+        long = "key-server",
+        value_name = "KEY_SERVER",
+        env = "BINDLE_KEY_SERVER",
+        conflicts_with = "use-host",
+        help = "Sets the server address and path to use for fetching keys. Should be a full url path (e.g. https://my.server.com/api/v1/bindle-keys). If this is not set, --host is implied"
+    )]
+    pub key_server: Option<url::Url>,
+    #[clap(
+        long = "host",
+        value_name = "USE_HOST",
+        id = "use-host",
+        help = "Fetches keys from the bindle server set by BINDLE_URL. This is mutually exclusive with --key-server"
+    )]
+    pub use_host: bool,
 }
 
 #[derive(Parser)]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -668,7 +668,7 @@ async fn unwrap_status(
         _ => Err(ClientError::Other(format!(
             "Unknown error response: {:?} to {} returned status {}: {}",
             operation,
-            resp.url().to_string(),
+            resp.url().to_owned(),
             resp.status(),
             parse_error_from_body(resp)
                 .await

--- a/src/invoice/mod.rs
+++ b/src/invoice/mod.rs
@@ -18,7 +18,9 @@ pub(crate) use api::DeviceAuthorizationExtraFields;
 #[doc(inline)]
 pub(crate) use api::LoginParams;
 #[doc(inline)]
-pub use api::{ErrorResponse, InvoiceCreateResponse, MissingParcelsResponse, QueryOptions};
+pub use api::{
+    ErrorResponse, InvoiceCreateResponse, KeyOptions, MissingParcelsResponse, QueryOptions,
+};
 #[doc(inline)]
 pub use bindle_spec::BindleSpec;
 #[doc(inline)]

--- a/src/provider/embedded.rs
+++ b/src/provider/embedded.rs
@@ -442,7 +442,7 @@ where
         remaining_permits = semaphore.available_permits(),
         "Successfully acquired spawn_blocking permit"
     );
-    Ok(tokio::task::spawn_blocking(f)
+    tokio::task::spawn_blocking(f)
         .await
-        .map_err(|_| ProviderError::Other("Internal error: unable to lock task".into()))?)
+        .map_err(|_| ProviderError::Other("Internal error: unable to lock task".into()))
 }

--- a/src/provider/file/mod.rs
+++ b/src/provider/file/mod.rs
@@ -682,11 +682,7 @@ mod test {
         // Create a temporary directory
         let root = tempdir().unwrap();
         let scaffold = testing::Scaffold::load("valid_v1").await;
-        let store = FileProvider::new(
-            root.path().to_owned(),
-            crate::search::StrictEngine::default(),
-        )
-        .await;
+        let store = FileProvider::new(root.path(), crate::search::StrictEngine::default()).await;
         let inv_name = scaffold.invoice.canonical_name();
 
         let signed = NoopSigned(NoopVerified(scaffold.invoice.clone()));
@@ -720,11 +716,7 @@ mod test {
         let root = tempdir().unwrap();
         let mut scaffold = testing::Scaffold::load("valid_v1").await;
         scaffold.invoice.yanked = Some(true);
-        let store = FileProvider::new(
-            root.path().to_owned(),
-            crate::search::StrictEngine::default(),
-        )
-        .await;
+        let store = FileProvider::new(root.path(), crate::search::StrictEngine::default()).await;
 
         let signed = NoopSigned(NoopVerified(scaffold.invoice.clone()));
         assert!(store.create_invoice(signed).await.is_err());
@@ -735,11 +727,7 @@ mod test {
         let scaffold = testing::Scaffold::load("valid_v1").await;
         let parcel = scaffold.parcel_files.get("parcel").unwrap();
         let root = tempdir().expect("create tempdir");
-        let store = FileProvider::new(
-            root.path().to_owned(),
-            crate::search::StrictEngine::default(),
-        )
-        .await;
+        let store = FileProvider::new(root.path(), crate::search::StrictEngine::default()).await;
 
         let signed = NoopSigned(NoopVerified(scaffold.invoice.clone()));
         // Create the invoice so we can create a parcel
@@ -785,11 +773,7 @@ mod test {
     #[tokio::test]
     async fn test_should_store_and_retrieve_bindle() {
         let root = tempdir().expect("create tempdir");
-        let store = FileProvider::new(
-            root.path().to_owned(),
-            crate::search::StrictEngine::default(),
-        )
-        .await;
+        let store = FileProvider::new(root.path(), crate::search::StrictEngine::default()).await;
 
         let scaffold = testing::Scaffold::load("valid_v1").await;
 
@@ -834,11 +818,7 @@ mod test {
         // Completely invalid size
         parcels[0].label.size = 100000;
         scaffold.invoice.parcel = Some(parcels);
-        let store = FileProvider::new(
-            root.path().to_owned(),
-            crate::search::StrictEngine::default(),
-        )
-        .await;
+        let store = FileProvider::new(root.path(), crate::search::StrictEngine::default()).await;
 
         let signed = NoopSigned(NoopVerified(scaffold.invoice.clone()));
         store
@@ -867,11 +847,7 @@ mod test {
         // Create a temporary directory
         let root = tempdir().unwrap();
         let scaffold = testing::Scaffold::load("valid_v1").await;
-        let store = FileProvider::new(
-            root.path().to_owned(),
-            crate::search::StrictEngine::default(),
-        )
-        .await;
+        let store = FileProvider::new(root.path(), crate::search::StrictEngine::default()).await;
 
         // We want two copies to try and write at the same time
         let signed1 = NoopSigned(NoopVerified(scaffold.invoice.clone()));

--- a/src/standalone/mod.rs
+++ b/src/standalone/mod.rs
@@ -108,7 +108,7 @@ impl StandaloneRead {
             )));
         }
 
-        parse_dir(entry.path().to_owned(), Some(tempdir)).await
+        parse_dir(entry.path(), Some(tempdir)).await
     }
 
     /// Push this standalone bindle to a bindle server using the given client. This function will

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -190,7 +190,7 @@ impl From<RawScaffold> for Scaffold {
 pub async fn setup() -> (FileProvider<StrictEngine>, StrictEngine, MockKeyStore) {
     let temp = tempdir().expect("unable to create tempdir");
     let index = StrictEngine::default();
-    let store = FileProvider::new(temp.path().to_owned(), index.clone()).await;
+    let store = FileProvider::new(temp.path(), index.clone()).await;
     let kstore = MockKeyStore::new();
     (store, index, kstore)
 }
@@ -200,7 +200,7 @@ pub async fn setup() -> (FileProvider<StrictEngine>, StrictEngine, MockKeyStore)
 pub async fn setup_embedded() -> (EmbeddedProvider<StrictEngine>, StrictEngine, MockKeyStore) {
     let temp = tempdir().expect("unable to create tempdir");
     let index = StrictEngine::default();
-    let store = EmbeddedProvider::new(temp.path().to_owned(), index.clone())
+    let store = EmbeddedProvider::new(temp.path(), index.clone())
         .await
         .expect("Unable to configure embedded provider");
     let kstore = MockKeyStore::new();
@@ -302,5 +302,13 @@ impl SecretKeyStorage for MockKeyStore {
         _match_type: Option<&LabelMatch>,
     ) -> Option<&SecretKeyEntry> {
         Some(&self.mock_secret_key)
+    }
+
+    fn get_all_matching(
+        &self,
+        _role: &SignatureRole,
+        _match_type: Option<&LabelMatch>,
+    ) -> Vec<&SecretKeyEntry> {
+        vec![&self.mock_secret_key]
     }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -248,3 +248,18 @@ async fn test_charset() {
         .await
         .expect("Content-Type with charset shouldn't fail");
 }
+
+#[tokio::test]
+async fn test_bindle_keys() {
+    let controller = TestController::new(BINARY_NAME).await;
+
+    let keyring = controller
+        .client
+        .get_host_keys()
+        .await
+        .expect("Should be able to fetch host keys using client");
+    assert!(
+        !keyring.key.is_empty(),
+        "Keyring should contain at least one key"
+    );
+}


### PR DESCRIPTION
This adds support for the new `bindle-keys` endpoint to the bindle server as well as client code for consuming that end point. Note that this has one small breaking change for the `raw` method on the `Client`. 

I also fixed some clippy lints that had snuck past us