### PR TITLE
fix(wasm): Fixes deps for building in wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default = ["server", "client", "caching", "test-tools", "native-tls"]
 server = ["warp", "openid", "hyper", "mime", "either", "_common"]
 client = ["mime_guess", "dirs", "time", "async-compression", "tokio-tar", "_common"]
 # Internal use only feature that groups all of the optional deps we need for both server and client
-_common = ["providers", "tokio/full", "tokio-util", "oauth2", "reqwest"]
+_common = ["providers", "tokio/full", "tokio-util", "oauth2", "reqwest", "tokio-stream/fs"]
 # Activates provider implementations
 providers = ["lru", "serde_cbor", "sled"]
 caching = ["lru"]
@@ -74,8 +74,8 @@ sled = { version = "0.34.7", optional = true }
 tempfile = "3.2.0"
 thiserror = "1.0.29"
 time = { version = "0.3", features = ["serde"], optional = true }
-tokio = { version = "1.11.0", default-features = false, features = ["fs", "sync", "io-util"] }
-tokio-stream = { version = "0.1.7", features = ["fs"] }
+tokio = { version = "1.11.0", default-features = false, features = ["sync", "io-util"] }
+tokio-stream = { version = "0.1.7" }
 tokio-tar = { version = "0.3", optional = true }
 tokio-util = { version = "0.7", features = ["io", "codec"], optional = true }
 toml = "0.5.8"

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -175,12 +175,8 @@ impl<'a> BindleFilter<'a> {
     /// returned in the filter result if something else does not remove them.
     pub fn activate_feature(&mut self, group: &str, name: &str, value: &str) -> &mut Self {
         // This is a hack to remove duplicate group/name pairs.
-        self.features = self
-            .features
-            .iter()
-            .filter(|i| !(i.name == name && i.group == group))
-            .cloned()
-            .collect();
+        self.features
+            .retain(|i| !(i.name == name && i.group == group));
 
         self.features.push(FeatureReference {
             group: group.to_owned(),

--- a/src/invoice/verification.rs
+++ b/src/invoice/verification.rs
@@ -43,7 +43,7 @@ pub enum VerificationStrategy {
     /// Verifies that all signatures of the given roles are valid and signed by known keys. Will
     /// also validate unknown signers similar to GreedyVerification
     ///
-    /// If the bool is true, unknown signers will also be validated. Be aware that doing so may make
+    /// Unknown signers will also be validated. Be aware that doing so may make
     /// the validation subject to a special form of DOS attack in which someone can generate a
     /// known-bad signature.
     MultipleAttestationGreedy(Vec<SignatureRole>),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -18,7 +18,7 @@ const TEST_LABEL: &str = "Benjamin Sisko <thesisko@bajor.com>";
 async fn setup_data<T: TokenManager>(client: &Client<T>) {
     // For now let's just put in a simple manifest and one with a lot of parcels
     for name in &["valid_v1", "lotsa_parcels"] {
-        let scaffold = testing::Scaffold::load(*name).await;
+        let scaffold = testing::Scaffold::load(name).await;
         client
             .create_invoice(scaffold.invoice.clone())
             .await
@@ -47,7 +47,7 @@ async fn test_push() {
     let path = std::path::PathBuf::from(root).join("test/data/standalone");
     // TODO: Figure out how to dedup these outputs. I tried doing something but `args` returns an `&mut` which complicates things
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -72,7 +72,7 @@ async fn test_push_tarball() {
     let path = std::path::PathBuf::from(root).join("test/data/standalone");
     // TODO: Figure out how to dedup these outputs. I tried doing something but `args` returns an `&mut` which complicates things
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -96,7 +96,7 @@ async fn test_push_invoice_and_file() {
     let root = std::env::var("CARGO_MANIFEST_DIR").expect("Unable to get project directory");
     let base = std::path::PathBuf::from(root).join("tests/scaffolds/valid_v1");
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -114,7 +114,7 @@ async fn test_push_invoice_and_file() {
 
     // Now try to push a file from the bindle
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -137,7 +137,7 @@ async fn test_get() {
     setup_data(&controller.client).await;
     let cachedir = tempfile::tempdir().expect("unable to set up tempdir");
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -158,7 +158,7 @@ async fn test_get() {
 
     // This is a sanity check test to make sure a second call triggers the code path for successfully fetching from the cache
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -180,7 +180,7 @@ async fn test_get() {
     // Now try and export to a test directory and make sure it is there
     let tempdir = tempfile::tempdir().expect("Unable to set up tempdir");
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -221,7 +221,7 @@ async fn test_get_invoice() {
     let tempdir = tempfile::tempdir().expect("Unable to set up tempdir");
     let cachedir = tempfile::tempdir().expect("Unable to set up tempdir");
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -302,7 +302,7 @@ async fn test_get_parcel() {
     let tempdir = tempfile::tempdir().expect("Unable to set up tempdir");
     let cachedir = tempfile::tempdir().expect("Unable to set up tempdir");
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -337,7 +337,7 @@ async fn test_yank() {
     setup_data(&controller.client).await;
 
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -358,7 +358,7 @@ async fn test_yank() {
 async fn test_no_bindles() {
     let controller = TestController::new(BINARY_NAME).await;
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -389,7 +389,7 @@ async fn test_package() {
     let path = std::path::PathBuf::from(root).join("test/data/standalone");
     // TODO: Figure out how to dedup these outputs. I tried doing something but `args` returns an `&mut` which complicates things
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -520,7 +520,7 @@ async fn test_keyring_add() {
     let keyring_file = tempdir.path().join(KEYRING_FILE);
 
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -574,7 +574,7 @@ async fn test_keyring_add_to_existing() {
 
     let second_label = "Miles O'Brien <everyman@ufp.com>";
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -614,7 +614,7 @@ async fn test_fetch_host_keys() {
 
     let controller = TestController::new(BINARY_NAME).await;
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",
@@ -654,7 +654,7 @@ async fn test_fetch_host_keys_from_specific_host() {
 
     let controller = TestController::new(BINARY_NAME).await;
     let output = std::process::Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--features",
             "cli",

--- a/tests/test_util.rs
+++ b/tests/test_util.rs
@@ -36,7 +36,7 @@ impl TestController {
     pub async fn new(server_binary_name: &str) -> TestController {
         let build_result = tokio::task::spawn_blocking(|| {
             std::process::Command::new("cargo")
-                .args(&["build", "--features", "cli"])
+                .args(["build", "--features", "cli"])
                 .output()
         })
         .await
@@ -90,7 +90,7 @@ impl TestController {
                 .join("target/debug")
                 .join(server_binary_name),
         )
-        .args(&[
+        .args([
             "--unauthenticated",
             "-d",
             tempdir.path().to_string_lossy().to_string().as_str(),


### PR DESCRIPTION
A while ago we made sure that if you wanted to pull in the base bindle types into something compiling to wasm, it would build. Recently, tokio made a change that made it so it wouldn't compile for wasm with the `fs` feature enabled. This makes sense, but I did have to untangle some fs stuff from the signatures module.

While I was here I fixed a bunch of new clippy lints from the latest version of clippy