### PR TITLE
chore(release/0.8): cherry-pick CI features/fixes

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,13 @@ jobs:
               targetPath: "target/release/",
             }
           - {
+              os: "ubuntu-latest",
+              arch: "aarch64",
+              extension: "",
+              env: { OPENSSL_DIR: "/usr/local/openssl-aarch64" },
+              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+            }
+          - {
               os: "macos-latest",
               arch: "amd64",
               extension: "",
@@ -68,14 +75,37 @@ jobs:
           default: true
           components: clippy, rustfmt
 
+      - name: setup for cross-compile builds
+        if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-latest'
+        run: |
+          sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          cd /tmp
+          git clone https://github.com/openssl/openssl
+          cd openssl
+          git checkout OpenSSL_1_1_1l
+          sudo mkdir -p $OPENSSL_DIR
+          ./Configure linux-aarch64 --prefix=$OPENSSL_DIR --openssldir=$OPENSSL_DIR shared
+          make CC=aarch64-linux-gnu-gcc
+          sudo make install
+          rustup target add aarch64-unknown-linux-gnu
+
       - name: Install latest Rust stable toolchain
         uses: actions-rs/toolchain@v1
-        if: matrix.config.arch == 'aarch64'
+        if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
         with:
           toolchain: stable
           default: true
           components: clippy, rustfmt
           target: aarch64-apple-darwin
+
+      - name: Install latest Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-latest'
+        with:
+          toolchain: stable
+          default: true
+          components: clippy, rustfmt
+          target: aarch64-unknown-linux-gnu
 
       - name: build release
         uses: actions-rs/cargo@v1
@@ -86,10 +116,17 @@ jobs:
 
       - name: build release
         uses: actions-rs/cargo@v1
-        if: matrix.config.arch == 'aarch64'
+        if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
         with:
           command: build
           args: "--all-features --release --target aarch64-apple-darwin"
+
+      - name: build release
+        uses: actions-rs/cargo@v1
+        if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-latest'
+        with:
+          command: build
+          args: "--all-features --release --target aarch64-unknown-linux-gnu"
 
       - name: package release assets
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,7 +162,7 @@ jobs:
           cd bindle
           sha256sum * > checksums-${{ env.RELEASE_VERSION }}.txt
       - name: upload to azure
-        uses: bacongobbler/azure-blob-storage-upload@v2.0.0
+        uses: bacongobbler/azure-blob-storage-upload@v2.0.1
         with:
           source_dir: bindle
           container_name: releases

--- a/deny.toml
+++ b/deny.toml
@@ -78,6 +78,7 @@ unlicensed = "deny"
 allow = [
     "LicenseRef-ring",
     "MPL-2.0",
+    "Unicode-DFS-2016"
 ]
 # List of explictly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses


### PR DESCRIPTION
@thomastaylor312 and @bacongobbler, does the following look like the right approach towards the goal of backporting some CI improvements/fixes into a v0.8.x release (would be v0.8.2 as of writing)?

Ref https://github.com/deislabs/bindle/issues/325

It incorporates both the [linux-aarch64 build support](https://github.com/deislabs/bindle/pull/328) and the [blob-store action bump/fix](https://github.com/deislabs/bindle/pull/355).  I ran the following:

```
git checkout release/0.8

# cherry-pick the linux-aarch64 commit
git cherry-pick f7e31ccc5587c7444ef73bba702ec082f37cf345

# cherry-pick the azure-blob-store bump
git cherry-pick a5ba2c91cbfd7e1099c432cd4ae6c9e88b32f94a
```

**edit: also added this change to pass CI: https://github.com/deislabs/bindle/pull/359/commits/05d7a2557f12b399f44a2f1298df25f3349b6d47 ; ref https://github.com/deislabs/bindle/pull/359#issuecomment-1347318904**

If so, then I suppose we'd merge this into `release/0.8` and then tag/push `v0.8.2` from HEAD of this branch?