### PR TITLE
fix(release.yaml): add apt-get update in aarch64 build step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,6 +78,7 @@ jobs:
       - name: setup for cross-compile builds
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-latest'
         run: |
+          sudo apt-get update
           sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           cd /tmp
           git clone https://github.com/openssl/openssl


### PR DESCRIPTION
Fix for error seen recently in the release workflow, eg https://github.com/deislabs/bindle/actions/runs/3679702313/jobs/6224462114

I tested with a fresh/stock Ubuntu 22.04 AMI in AWS.  Reproduced the error and it looks like the `apt-get update` indeed unblocks the apt installs.