### PR TITLE
fix(release.yaml): add apt-get update in aarch64 build step (#360)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,6 +78,7 @@ jobs:
       - name: setup for cross-compile builds
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-latest'
         run: |
+          sudo apt-get update
           sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           cd /tmp
           git clone https://github.com/openssl/openssl


### PR DESCRIPTION
Cherry-picks the commit from https://github.com/deislabs/bindle/pull/360 to fix the release automation and unblock v0.8.2

Ref https://github.com/deislabs/bindle/issues/325