### PR TITLE
chore(Cargo.toml): bump version to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "bindle"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bindle"
-version = "0.8.1"
+version = "0.8.2"
 authors = [
     "Matt Butcher <matt.butcher@microsoft.com>",
     "Taylor Thomas <taylor.thomas@microsoft.com>"


### PR DESCRIPTION
Bumps the version to 0.8.2 on the release/0.8 branch; ref https://github.com/deislabs/bindle/issues/325#issuecomment-1360270947

I'll re-push the v0.8.2 tag once this is merged.